### PR TITLE
Update JMH to 1.25.2

### DIFF
--- a/jol-benchmarks/pom.xml
+++ b/jol-benchmarks/pom.xml
@@ -65,7 +65,7 @@
         <!--
             JMH version to use with this project.
           -->
-        <jmh.version>1.23</jmh.version>
+        <jmh.version>1.25.2</jmh.version>
 
         <!--
             Name of the benchmark Uber-JAR to generate.


### PR DESCRIPTION
Update JMH dependency to 1.25.2.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Download
`$ git fetch https://git.openjdk.java.net/jol pull/2/head:pull/2`
`$ git checkout pull/2`
