### PR TITLE
Fix maven-surefire-plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,6 +117,11 @@ questions.
                     <artifactId>maven-shade-plugin</artifactId>
                     <version>3.2.1</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>3.0.0-M5</version>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>


### PR DESCRIPTION
Maven complains otherwise:

```
[WARNING] 
[WARNING] Some problems were encountered while building the effective model for org.openjdk.jol:jol-core:jar:0.14-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.apache.maven.plugins:maven-surefire-plugin is missing. @ org.openjdk.jol:jol-core:[unknown-version], /home/shade/temp/jol/jol/jol-core/pom.xml, line 66, column 21
[WARNING] 
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING] 
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Download
`$ git fetch https://git.openjdk.java.net/jol pull/6/head:pull/6`
`$ git checkout pull/6`
