### PR TITLE
Cleanups: README typos and links, .gitignore, leftover JDK migrations, column widths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea/
+*.iml
+target/

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ This dives into Object layout: field layout within the object, header informatio
 #### "externals"
 
 This dives into the Object graphs layout: list objects reachable from the instance,
-their addresses, paths through the reachability graph, etc (is is more
+their addresses, paths through the reachability graph, etc (is more
 convenient with API though).
 
     $ java -jar jol-cli.jar externals java.lang.String
@@ -136,12 +136,14 @@ This gets the object footprint estimate, similar to the object externals, but ta
 
 ## Reporting Bugs
 
-If you have the access to [JDK Bug System](https://bugs.openjdk.java.net/), please submit the bug there:
- * Project: CODETOOLS
- * Component: tools
- * Sub-component: jol
+You may find unresolved bugs and feature request in 
+[JDK Bug System](https://bugs.openjdk.java.net/issues/?jql=project%20%3D%20CODETOOLS%20AND%20resolution%20%3D%20Unresolved%20AND%20component%20%3D%20tools%20AND%20Subcomponent%20%3D%20jol) 
+Please submit the new bug there:
+ * Project: `CODETOOLS`
+ * Component: `tools`
+ * Sub-component: `jol`
 
-If you don't have the access to JDK Bug System, submit the bug report at "Issues" here, and wait for maintainers to pick that up.
+If you don't have the access to JDK Bug System, submit the bug report at [Issues](https://github.com/openjdk/jol/issues) here, and wait for maintainers to pick that up.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -159,3 +159,7 @@ Compile and run tests:
 Tests would normally run in many JVM configurations. If you are contributing the code,
 please try to run the build on multiple JDK releases, most importantly 8u and 11u.
 GitHub workflow "JOL Pre-Integration Tests" should pass with your changes.
+
+## Related projects
+
+* [IntelliJ IDEA JOL Plugin](https://github.com/stokito/IdeaJol) can estimate object size and has an inspection to find heavy classes

--- a/jol-cli/src/main/java/org/openjdk/jol/operations/ObjectShapes.java
+++ b/jol-cli/src/main/java/org/openjdk/jol/operations/ObjectShapes.java
@@ -115,9 +115,9 @@ public class ObjectShapes implements Operation {
             URLClassLoader cl = URLClassLoader.newInstance(new URL[]{new URL("jar:file:" + jarName + "!/")});
 
             JarFile jarFile = new JarFile(jarName);
-            Enumeration e = jarFile.entries();
+            Enumeration<JarEntry> e = jarFile.entries();
             while (e.hasMoreElements()) {
-                JarEntry je = (JarEntry) e.nextElement();
+                JarEntry je = e.nextElement();
                 String name = je.getName();
                 if (je.isDirectory()) continue;
                 if (!name.endsWith(".class")) continue;

--- a/jol-cli/src/main/java/org/openjdk/jol/operations/StringCompress.java
+++ b/jol-cli/src/main/java/org/openjdk/jol/operations/StringCompress.java
@@ -86,7 +86,7 @@ public class StringCompress implements Operation {
         }
 
         if (DO_MODE.equalsIgnoreCase("histo")) {
-            out.printf("%15s, %15s, %15s, %s%n",
+            out.printf("%15s, %15s, %18s, %s%n",
                     "\"size\"", "\"compressible\"", "\"non-compressible\"", "\"hprof file\"");
         } else if (DO_MODE.equalsIgnoreCase("estimates")) {
             out.printf("%15s, %15s, %15s, %15s, %15s, %15s, %15s, %15s, %15s, %s, %s%n",
@@ -197,7 +197,7 @@ public class StringCompress implements Operation {
                 sizes.addAll(nonCompressibleCharArrays.keys());
 
                 for (Integer s : sizes) {
-                    out.printf("%15d, %15d, %15d, \"%s\"%n", s, compressibleCharArrays.count(s), nonCompressibleCharArrays.count(s), path);
+                    out.printf("%15d, %15d, %18d, \"%s\"%n", s, compressibleCharArrays.count(s), nonCompressibleCharArrays.count(s), path);
                 }
             } else if (DO_MODE.equalsIgnoreCase("estimates")) {
                 for (DataModel model : DATA_MODELS) {

--- a/jol-cli/src/main/java/org/openjdk/jol/operations/StringCompress.java
+++ b/jol-cli/src/main/java/org/openjdk/jol/operations/StringCompress.java
@@ -89,9 +89,9 @@ public class StringCompress implements Operation {
             out.printf("%15s, %15s, %18s, %s%n",
                     "\"size\"", "\"compressible\"", "\"non-compressible\"", "\"hprof file\"");
         } else if (DO_MODE.equalsIgnoreCase("estimates")) {
-            out.printf("%15s, %15s, %15s, %15s, %15s, %15s, %15s, %15s, %15s, %s, %s%n",
+            out.printf("%15s, %15s, %15s, %15s, %15s, %15s, %15s, %15s, %15s, %s, %70s, %s%n",
                     "\"total\"", "\"String\"", "\"String+bool\"", "\"String+oop\"", "\"char[]-2b\"",
-                    "\"char[]-1b\"", "\"char[]-1b-comp\"", "\"savings(same)\"",  "\"savings(bool)\"", "\"savings(oop)\"", "\"hprof file\"", "\"model\"");
+                    "\"char[]-1b\"", "\"char[]-1b-comp\"", "\"savings(same)\"",  "\"savings(bool)\"", "\"savings(oop)\"", "\"model\"", "\"hprof file\"");
         }
 
         List<Future<?>> res = new ArrayList<>();
@@ -264,9 +264,9 @@ public class StringCompress implements Operation {
             double savingSame = 100.0 * ((compressibleBytes - compressedBytes)) / totalFootprint;
             double savingBool = 100.0 * ((compressibleBytes - compressedBytes) - (stringsBool - strings)) / totalFootprint;
             double savingOop  = 100.0 * ((compressibleBytes - compressedBytes) - (stringsOop - strings))  / totalFootprint;
-            out.printf("%15d, %15d, %15d, %15d, %15d, %15d, %15d, %15.3f, %15.3f, %15.3f, \"%s\", \"%s\"%n",
+            out.printf("%15d, %15d, %15d, %15d, %15d, %15d, %15d, %15.3f, %15.3f, %15.3f, %70s, \"%s\"%n",
                     totalFootprint, strings, stringsBool, stringsOop, nonCompressibleBytes, compressibleBytes, compressedBytes,
-                    savingSame, savingBool, savingOop, path, l);
+                    savingSame, savingBool, savingOop, "\"" + l + "\"", path);
         }
 
         public static boolean isCompressible(byte[] bytes) {


### PR DESCRIPTION
Some non critical changes:
1. Currently the repo has `.hgignore` file but don't have a `.gitignore`. I copied it from `.hgignore` but not sure if we can remove it as not used.
2. I shamelessly added my IdeJOL plugin to README. There is also mentioned that we can create an issue here on GitHub but currently the Issues tab is disabled. The same is for JMH repo. Can you open the issues tab?
3. I noted that in `StringCompress` we have a minor bug where in println format pattern we have less placeholders than params. While investigated it turned out that it will be better to swap "model" and "hprof file" columns for better output. Now it looks like:
```
"total", "String", "String+bool",    "String+oop",  "char[]-2b", "char[]-1b", "char[]-1b-comp", "savings(same)", "savings(bool)", "savings(oop)",                                                                "model", "hprof file"
3918376,    59992,         59992,           59992,            0,           0,               0,           0.000,           0.000,           0.000,                     "VM Layout Simulation (X32 model, 8-byte aligned)", "~/empty.hprof"
4323184,   119984,        119984,          119984,            0,           0,               0,           0.000,           0.000,           0.000,                     "VM Layout Simulation (X64 model, 8-byte aligned)", "~/empty.hprof"
4056392,   119984,        119984,          119984,            0,           0,               0,           0.000,           0.000,           0.000,   "VM Layout Simulation (X64 model (compressed oops), 8-byte aligned)", "~/empty.hprof"
4116336,   119984,        119984,          119984,            0,           0,               0,           0.000,           0.000,           0.000,  "VM Layout Simulation (X64 model (compressed oops), 16-byte aligned)", "~/empty.hprof"
```

Also I tried to add a unit test for heap dump analyzer because it currently doesn't have any coverage.
The test should analyze a heap dump and compare results. But got few problems that want to discuss and since there is a closed Issues tab then I'll write it here.
First if all I made a heap dump of a "Hello World" application on JDK14 and the resulted file even gzipped is more than 900Kb. 
I don't want to add such a big file into test resources. So here I see two solutions:
1. Create a synthetic heap dump with only few rows.
2. Start a small application and get it's thread dump. This wont work because each time we'll get some classes changed.
Can you create a small heap dump file for a testing?

Another problem I faced when tried to test `StringComprees` with my empty thread dump and got an exception `org.openjdk.jol.heap.HeapDumpException: String.value array 34355822528 is not char[] in empty.hprof.gz, skipping`
This is probably a bug in the JOL itself so I'll attach the [empty.hprof.gz](https://github.com/openjdk/jol/files/5346882/empty.hprof.gz) for you to reproduce.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Reviewers
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - Committer) ⚠️ Review applies to 3260070150d052196a05c24ef6e8df0f816dc765


### Download
`$ git fetch https://git.openjdk.java.net/jol pull/7/head:pull/7`
`$ git checkout pull/7`
