### PR TITLE
CODETOOLS-7902835: JOL: ObjectShapes.processJAR should close resources properly

### DIFF
--- a/jol-cli/src/main/java/org/openjdk/jol/operations/ObjectShapes.java
+++ b/jol-cli/src/main/java/org/openjdk/jol/operations/ObjectShapes.java
@@ -111,10 +111,9 @@ public class ObjectShapes implements Operation {
 
     private Multiset<String> processJAR(String jarName) {
         Multiset<String> shapes = new Multiset<>();
-        try {
-            URLClassLoader cl = URLClassLoader.newInstance(new URL[]{new URL("jar:file:" + jarName + "!/")});
+        try (URLClassLoader cl = URLClassLoader.newInstance(new URL[]{new URL("jar:file:" + jarName + "!/")});
+             JarFile jarFile = new JarFile(jarName)){
 
-            JarFile jarFile = new JarFile(jarName);
             Enumeration<JarEntry> e = jarFile.entries();
             while (e.hasMoreElements()) {
                 JarEntry je = e.nextElement();
@@ -124,16 +123,14 @@ public class ObjectShapes implements Operation {
 
                 String className = name.substring(0, name.length() - 6).replace('/', '.');
                 try {
-                    Class klass = cl.loadClass(className);
+                    Class<?> klass = cl.loadClass(className);
                     ClassData cd = ClassData.parseClass(klass);
                     String shape = parseClassData(cd);
                     shapes.add(shape);
-                } catch (Error t) {
                 } catch (Throwable t) {
-                    t.printStackTrace();
+                    t.printStackTrace(System.err);
                 }
             }
-            jarFile.close();
         } catch (Exception t) {
             // ignore
         }

--- a/jol-cli/src/main/java/org/openjdk/jol/operations/ObjectShapes.java
+++ b/jol-cli/src/main/java/org/openjdk/jol/operations/ObjectShapes.java
@@ -112,7 +112,7 @@ public class ObjectShapes implements Operation {
     private Multiset<String> processJAR(String jarName) {
         Multiset<String> shapes = new Multiset<>();
         try (URLClassLoader cl = URLClassLoader.newInstance(new URL[]{new URL("jar:file:" + jarName + "!/")});
-             JarFile jarFile = new JarFile(jarName)){
+             JarFile jarFile = new JarFile(jarName)) {
 
             Enumeration<JarEntry> e = jarFile.entries();
             while (e.hasMoreElements()) {


### PR DESCRIPTION
SonarCloud instance reports a few easy-to-fix issues in this method.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902835](https://bugs.openjdk.java.net/browse/CODETOOLS-7902835): JOL: ObjectShapes.processJAR should close resources properly


### Download
`$ git fetch https://git.openjdk.java.net/jol pull/9/head:pull/9`
`$ git checkout pull/9`
