### PR TITLE
CODETOOLS-7902836: JOL: Fix incorrect implicit numeric promotions

### DIFF
--- a/jol-core/src/main/java/org/openjdk/jol/heap/HeapDumpReader.java
+++ b/jol-core/src/main/java/org/openjdk/jol/heap/HeapDumpReader.java
@@ -237,7 +237,7 @@ public class HeapDumpReader {
         read_U4(); // stack trace
         int elements = (int) read_U4(); // always fits
         read_ID(); // type class
-        read_null(elements * idSize);
+        read_null((long) elements * idSize);
 
         // assume Object, we don't care about the exact types here
         classCounts.add(new ClassData("Object[]", "Object", elements));

--- a/jol-core/src/main/java/org/openjdk/jol/info/GraphLayout.java
+++ b/jol-core/src/main/java/org/openjdk/jol/info/GraphLayout.java
@@ -487,12 +487,15 @@ public class GraphLayout {
         g.drawString(String.format("%s", description), SCALE_WIDTH + EXT_PAD, 30);
 
         AffineTransform orig = g.getTransform();
-        g.rotate(-Math.toRadians(90.0), SCALE_WIDTH + EXT_PAD - 5, GRAPH_HEIGHT + EXT_PAD);
-        g.drawString("Actual:", SCALE_WIDTH + EXT_PAD - 5, GRAPH_HEIGHT + EXT_PAD);
+        int x = SCALE_WIDTH + EXT_PAD - 5;
+        int y1 = GRAPH_HEIGHT + EXT_PAD;
+        g.rotate(-Math.toRadians(90.0), x, y1);
+        g.drawString("Actual:", x, y1);
         g.setTransform(orig);
 
-        g.rotate(-Math.toRadians(90.0), SCALE_WIDTH + EXT_PAD - 5, 2 * GRAPH_HEIGHT + EXT_PAD + PAD);
-        g.drawString("Dense:", SCALE_WIDTH + EXT_PAD - 5, 2 * GRAPH_HEIGHT + EXT_PAD + PAD);
+        int y2 = 2 * GRAPH_HEIGHT + EXT_PAD + PAD;
+        g.rotate(-Math.toRadians(90.0), x, y2);
+        g.drawString("Dense:", x, y2);
         g.setTransform(orig);
 
         ImageIO.write(image, "png", new File(fileName));


### PR DESCRIPTION
SonarCloud instance reports a few places where implicit promotions are not what we want them to be. The most notorious please is in HeapDumpReader::digestObjArray.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902836](https://bugs.openjdk.java.net/browse/CODETOOLS-7902836): JOL: Fix incorrect implicit numeric promotions


### Download
`$ git fetch https://git.openjdk.java.net/jol pull/10/head:pull/10`
`$ git checkout pull/10`
