### PR TITLE
CODETOOLS-7902866: JOL: Rework the instance dump output: formatting, decoding mark/class words, array length

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,19 +67,18 @@ This dives into Object layout: field layout within the object, header informatio
     Instantiated the sample instance via default constructor.
 
     java.util.HashMap object internals:
-    OFFSET  SIZE                       TYPE DESCRIPTION                               VALUE
-         0     4                            (object header)                           01 00 00 00 (1)
-         4     4                            (object header)                           00 00 00 00 (0)
-         8     4                            (object header)                           b8 b2 01 00 (111288)
-        12     4              java.util.Set AbstractMap.keySet                        null
-        16     4       java.util.Collection AbstractMap.values                        null
-        20     4                        int HashMap.size                              0
-        24     4                        int HashMap.modCount                          0
-        28     4                        int HashMap.threshold                         0
-        32     4                      float HashMap.loadFactor                        0.75
-        36     4   java.util.HashMap.Node[] HashMap.table                             null
-        40     4              java.util.Set HashMap.entrySet                          null
-        44     4                            (loss due to the next object alignment)
+    OFF  SZ                       TYPE DESCRIPTION               VALUE
+      0   8                            (object header: mark)     0x0000000000000005 (biasable; age: 0)
+      8   4                            (object header: class)    0x00019828
+     12   4              java.util.Set AbstractMap.keySet        null
+     16   4       java.util.Collection AbstractMap.values        null
+     20   4                        int HashMap.size              0
+     24   4                        int HashMap.modCount          0
+     28   4                        int HashMap.threshold         0
+     32   4                      float HashMap.loadFactor        0.75
+     36   4   java.util.HashMap.Node[] HashMap.table             null
+     40   4              java.util.Set HashMap.entrySet          null
+     44   4                            (object alignment gap)
     Instance size: 48 bytes
     Space losses: 0 bytes internal + 4 bytes external = 4 bytes total
 

--- a/jol-core/src/main/java/org/openjdk/jol/vm/HotspotUnsafe.java
+++ b/jol-core/src/main/java/org/openjdk/jol/vm/HotspotUnsafe.java
@@ -121,9 +121,14 @@ class HotspotUnsafe implements VirtualMachine {
         Boolean coops = VMOptions.pollCompressedOops();
         if (coops != null) {
             compressedOopsEnabled = coops;
-            compressedKlassOopsEnabled = coops;
         } else {
             compressedOopsEnabled = (addressSize != oopSize);
+        }
+
+        Boolean ccptrs = VMOptions.pollCompressedClassPointers();
+        if (ccptrs != null) {
+            compressedKlassOopsEnabled = ccptrs;
+        } else {
             compressedKlassOopsEnabled = (addressSize != oopSize);
         }
 
@@ -251,6 +256,16 @@ class HotspotUnsafe implements VirtualMachine {
         } catch (NoSuchFieldException e) {
             throw new IllegalStateException("Infrastructure failure, klass = " + klass, e);
         }
+    }
+
+    @Override
+    public int addressSize() {
+        return addressSize;
+    }
+
+    @Override
+    public boolean compressedKlassPtrs() {
+        return compressedKlassOopsEnabled;
     }
 
     @Override

--- a/jol-core/src/main/java/org/openjdk/jol/vm/HotspotUnsafe.java
+++ b/jol-core/src/main/java/org/openjdk/jol/vm/HotspotUnsafe.java
@@ -54,7 +54,6 @@ class HotspotUnsafe implements VirtualMachine {
     private final boolean compressedOopsEnabled;
     private final long    narrowOopBase;
     private final int     narrowOopShift;
-    private final int     klassOopSize;
     private final boolean compressedKlassOopsEnabled;
     private final long    narrowKlassBase;
     private final int     narrowKlassShift;
@@ -86,13 +85,12 @@ class HotspotUnsafe implements VirtualMachine {
 
         addressSize = saDetails.getAddressSize();
         oopSize = saDetails.getOopSize();
-        klassOopSize = saDetails.getKlassOopSize();
 
         objectHeaderSize = guessHeaderSize();
         arrayHeaderSize = objectHeaderSize + 4;
 
         compressedOopsEnabled = saDetails.isCompressedOopsEnabled();
-        compressedKlassOopsEnabled = saDetails.isCompressedKlassOopsEnabled();
+        compressedKlassOopsEnabled = saDetails.isCompressedKlassPtrsEnabled();
 
         objectAlignment = saDetails.getObjectAlignment();
 
@@ -113,7 +111,6 @@ class HotspotUnsafe implements VirtualMachine {
         addressSize = U.addressSize();
 
         oopSize = guessOopSize();
-        klassOopSize = oopSize;
 
         objectHeaderSize = guessHeaderSize();
         arrayHeaderSize = objectHeaderSize + 4;
@@ -264,8 +261,15 @@ class HotspotUnsafe implements VirtualMachine {
     }
 
     @Override
-    public boolean compressedKlassPtrs() {
-        return compressedKlassOopsEnabled;
+    public int classPointerSize() {
+        switch (addressSize) {
+            case 4:
+                return 4;
+            case 8:
+                return compressedKlassOopsEnabled ? 4 : 8;
+            default:
+                throw new IllegalStateException("Unknown address size:" + addressSize);
+        }
     }
 
     @Override

--- a/jol-core/src/main/java/org/openjdk/jol/vm/VMOptions.java
+++ b/jol-core/src/main/java/org/openjdk/jol/vm/VMOptions.java
@@ -49,6 +49,15 @@ class VMOptions {
         }
     }
 
+    public static Boolean pollCompressedClassPointers() {
+        try {
+            return Boolean.valueOf(getString("UseCompressedClassPointers"));
+        } catch (Exception exp) {
+            // TODO: log
+            return null;
+        }
+    }
+
     public static Integer pollObjectAlignment() {
         if (Boolean.TRUE.equals(pollCompressedOops())) {
             try {

--- a/jol-core/src/main/java/org/openjdk/jol/vm/VirtualMachine.java
+++ b/jol-core/src/main/java/org/openjdk/jol/vm/VirtualMachine.java
@@ -171,4 +171,8 @@ public interface VirtualMachine {
      * @return String details
      */
     String details();
+
+    int addressSize();
+
+    boolean compressedKlassPtrs();
 }

--- a/jol-core/src/main/java/org/openjdk/jol/vm/VirtualMachine.java
+++ b/jol-core/src/main/java/org/openjdk/jol/vm/VirtualMachine.java
@@ -95,6 +95,18 @@ public interface VirtualMachine {
     int arrayHeaderSize();
 
     /**
+     * Returns native address size.
+     * @return address size in bytes
+     */
+    int addressSize();
+
+    /**
+     * Returns class pointer size.
+     * @return class pointer size, in bytes
+     */
+    int classPointerSize();
+
+    /**
      * Reads a boolean off the object at given offset.
      * @param obj instance
      * @param offset offset
@@ -171,8 +183,4 @@ public interface VirtualMachine {
      * @return String details
      */
     String details();
-
-    int addressSize();
-
-    boolean compressedKlassPtrs();
 }

--- a/jol-core/src/main/java/org/openjdk/jol/vm/sa/UniverseData.java
+++ b/jol-core/src/main/java/org/openjdk/jol/vm/sa/UniverseData.java
@@ -40,22 +40,20 @@ public class UniverseData implements Result {
     private final long narrowOopBase;
     private final int narrowOopShift;
 
-    private final int klassOopSize;
-    private final boolean compressedKlassOopsEnabled;
+    private final boolean compressedKlassPtrsEnabled;
     private final long narrowKlassBase;
     private final int narrowKlassShift;
 
     public UniverseData(int addressSize, int objectAlignment, int oopSize,
-                        boolean compressedOopsEnabled, long narrowOopBase, int narrowOopShift, int klassOopSize,
-                        boolean compressedKlassOopsEnabled, long narrowKlassBase, int narrowKlassShift) {
+                        boolean compressedOopsEnabled, long narrowOopBase, int narrowOopShift,
+                        boolean compressedKlassPtrsEnabled, long narrowKlassBase, int narrowKlassShift) {
         this.addressSize = addressSize;
         this.objectAlignment = objectAlignment;
         this.oopSize = oopSize;
         this.compressedOopsEnabled = compressedOopsEnabled;
         this.narrowOopBase = narrowOopBase;
         this.narrowOopShift = narrowOopShift;
-        this.klassOopSize = klassOopSize;
-        this.compressedKlassOopsEnabled = compressedKlassOopsEnabled;
+        this.compressedKlassPtrsEnabled = compressedKlassPtrsEnabled;
         this.narrowKlassBase = narrowKlassBase;
         this.narrowKlassShift = narrowKlassShift;
     }
@@ -84,12 +82,8 @@ public class UniverseData implements Result {
         return narrowOopShift;
     }
 
-    public int getKlassOopSize() {
-        return klassOopSize;
-    }
-
-    public boolean isCompressedKlassOopsEnabled() {
-        return compressedKlassOopsEnabled;
+    public boolean isCompressedKlassPtrsEnabled() {
+        return compressedKlassPtrsEnabled;
     }
 
     public long getNarrowKlassBase() {

--- a/jol-core/src/main/java/org/openjdk/jol/vm/sa/UniverseTask.java
+++ b/jol-core/src/main/java/org/openjdk/jol/vm/sa/UniverseTask.java
@@ -53,14 +53,12 @@ class UniverseTask implements Task {
             Method getNarrowOopBaseMethod = universeClass.getMethod("getNarrowOopBase");
             Method getNarrowOopShiftMethod = universeClass.getMethod("getNarrowOopShift");
 
-            Method getKlassOopSizeMethod = null;
-            Method isCompressedKlassOopsEnabledMethod = null;
+            Method isCompressedKlassPtrsEnabledMethod = null;
             Method getNarrowKlassBaseMethod = null;
             Method getNarrowKlassShiftMethod = null;
 
             try {
-                getKlassOopSizeMethod = vmClass.getMethod("getKlassPtrSize");
-                isCompressedKlassOopsEnabledMethod = vmClass.getMethod("isCompressedKlassPointersEnabled");
+                isCompressedKlassPtrsEnabledMethod = vmClass.getMethod("isCompressedKlassPointersEnabled");
                 getNarrowKlassBaseMethod = universeClass.getMethod("getNarrowKlassBase");
                 getNarrowKlassShiftMethod = universeClass.getMethod("getNarrowKlassShift");
             } catch (NoSuchMethodException e) {
@@ -80,10 +78,8 @@ class UniverseTask implements Task {
              * use compressed oop references values instead of them.
              */
 
-            int klassOopSize = getKlassOopSizeMethod != null ?
-                    (Integer) getKlassOopSizeMethod.invoke(vm) : oopSize;
-            boolean compressedKlassOopsEnabled = isCompressedKlassOopsEnabledMethod != null ?
-                    (Boolean) isCompressedKlassOopsEnabledMethod.invoke(vm) : compressedOopsEnabled;
+            boolean compressedKlassPtrsEnabled = isCompressedKlassPtrsEnabledMethod != null ?
+                    (Boolean) isCompressedKlassPtrsEnabledMethod.invoke(vm) : compressedOopsEnabled;
             long narrowKlassBase = getNarrowKlassBaseMethod != null ?
                     (Long) getNarrowKlassBaseMethod.invoke(null) : narrowOopBase;
             int narrowKlassShift = getNarrowKlassShiftMethod != null ?
@@ -95,8 +91,7 @@ class UniverseTask implements Task {
                                                         compressedOopsEnabled,
                                                         narrowOopBase,
                                                         narrowOopShift,
-                                                        klassOopSize,
-                                                        compressedKlassOopsEnabled,
+                                                        compressedKlassPtrsEnabled,
                                                         narrowKlassBase,
                                                         narrowKlassShift);
         } catch (Throwable t) {


### PR DESCRIPTION
JOL already knows a lot about the target VM. It can also decode the object headers more verbosely.

`JOLSample_14_FatLocking` example output:

```
$ ~/Install/jdk11u-dev/bin/java -cp jol-samples/target/jol-samples.jar org.openjdk.jol.samples.JOLSample_14_FatLocking
# WARNING: Unable to get Instrumentation. Dynamic Attach failed. You may add this JAR as -javaagent manually, or supply -Djdk.attach.allowAttachSelf
# Running 64-bit HotSpot VM.
# Using compressed oop with 3-bit shift.
# Using compressed klass with 0x0000000800000000 base address and 0-bit shift.
# Objects are 8 bytes aligned.
# Field sizes by type: 4, 1, 1, 2, 2, 4, 4, 8, 8 [bytes]
# Array element sizes: 4, 1, 1, 2, 2, 4, 4, 8, 8 [bytes]

**** Fresh object
org.openjdk.jol.samples.JOLSample_14_FatLocking$A object internals:
OFF  SZ   TYPE DESCRIPTION               VALUE
  0   8        (object header: mark)     0x0000000000000005 (biasable; age: 0)
  8   4        (object header: class)    0x000d5d08
 12   4        (object alignment gap)    
Instance size: 16 bytes
Space losses: 0 bytes internal + 4 bytes external = 4 bytes total

**** Before the lock
org.openjdk.jol.samples.JOLSample_14_FatLocking$A object internals:
OFF  SZ   TYPE DESCRIPTION               VALUE
  0   8        (object header: mark)     0x00007f5eec70c005 (biased: 0x0000001fd7bb1c30; epoch: 0; age: 0)
  8   4        (object header: class)    0x000d5d08
 12   4        (object alignment gap)    
Instance size: 16 bytes
Space losses: 0 bytes internal + 4 bytes external = 4 bytes total

**** With the lock
org.openjdk.jol.samples.JOLSample_14_FatLocking$A object internals:
OFF  SZ   TYPE DESCRIPTION               VALUE
  0   8        (object header: mark)     0x00007f5e64008682 (fat lock: 0x00007f5e64008682)
  8   4        (object header: class)    0x000d5d08
 12   4        (object alignment gap)    
Instance size: 16 bytes
Space losses: 0 bytes internal + 4 bytes external = 4 bytes total

**** After the lock
org.openjdk.jol.samples.JOLSample_14_FatLocking$A object internals:
OFF  SZ   TYPE DESCRIPTION               VALUE
  0   8        (object header: mark)     0x00007f5e64008682 (fat lock: 0x00007f5e64008682)
  8   4        (object header: class)    0x000d5d08
 12   4        (object alignment gap)    
Instance size: 16 bytes
Space losses: 0 bytes internal + 4 bytes external = 4 bytes total

**** After System.gc()
org.openjdk.jol.samples.JOLSample_14_FatLocking$A object internals:
OFF  SZ   TYPE DESCRIPTION               VALUE
  0   8        (object header: mark)     0x0000000000000001 (non-biasable; age: 0)
  8   4        (object header: class)    0x000d5d08
 12   4        (object alignment gap)    
Instance size: 16 bytes
Space losses: 0 bytes internal + 4 bytes external = 4 bytes total
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902866](https://bugs.openjdk.java.net/browse/CODETOOLS-7902866): JOL: Rework the instance dump output: formatting, decoding mark/class words, array length


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jol pull/11/head:pull/11` \
`$ git checkout pull/11`

Update a local copy of the PR: \
`$ git checkout pull/11` \
`$ git pull https://git.openjdk.java.net/jol pull/11/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 11`

View PR using the GUI difftool: \
`$ git pr show -t 11`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jol/pull/11.diff">https://git.openjdk.java.net/jol/pull/11.diff</a>

</details>
