### PR TITLE
CODETOOLS-7902869: JOL: Support JDK 15+ field layouter simulation

### DIFF
--- a/jol-cli/src/main/java/org/openjdk/jol/operations/HeapDumpStats.java
+++ b/jol-cli/src/main/java/org/openjdk/jol/operations/HeapDumpStats.java
@@ -70,7 +70,7 @@ public class HeapDumpStats implements Operation {
         final Multiset<String> counts = new Multiset<>();
         final Multiset<String> sizes = new Multiset<>();
 
-        Layouter layouter = new HotSpotLayouter(new ModelVM());
+        Layouter layouter = new HotSpotLayouter(new ModelVM(), 8);
         for (ClassData cd : data.keys()) {
             long size = layouter.layout(cd).instanceSize();
             counts.add(cd.name(), data.count(cd));

--- a/jol-cli/src/main/java/org/openjdk/jol/operations/ObjectEstimates.java
+++ b/jol-cli/src/main/java/org/openjdk/jol/operations/ObjectEstimates.java
@@ -46,14 +46,14 @@ public class ObjectEstimates extends ClasspathedOperation {
         return "Simulate the class layout in different VM modes.";
     }
 
-    static final DataModel[] MODELS_JDK8 = new DataModel[]{
+    private static final DataModel[] MODELS_JDK8 = new DataModel[]{
             new Model32(),
             new Model64(),
             new Model64_COOPS_CCPS(),
             new Model64_COOPS_CCPS(16),
     };
 
-    static final DataModel[] MODELS_JDK15 = new DataModel[]{
+    private static final DataModel[] MODELS_JDK15 = new DataModel[]{
             new Model64_CCPS(),
             new Model64_CCPS(16),
     };

--- a/jol-cli/src/main/java/org/openjdk/jol/operations/ObjectEstimates.java
+++ b/jol-cli/src/main/java/org/openjdk/jol/operations/ObjectEstimates.java
@@ -27,6 +27,7 @@ package org.openjdk.jol.operations;
 import org.openjdk.jol.datamodel.*;
 import org.openjdk.jol.info.ClassLayout;
 import org.openjdk.jol.layouters.HotSpotLayouter;
+import org.openjdk.jol.layouters.Layouter;
 
 import static java.lang.System.out;
 
@@ -45,20 +46,36 @@ public class ObjectEstimates extends ClasspathedOperation {
         return "Simulate the class layout in different VM modes.";
     }
 
-    static final DataModel[] DATA_MODELS = new DataModel[]{
+    static final DataModel[] MODELS_JDK8 = new DataModel[]{
             new Model32(),
             new Model64(),
             new Model64_COOPS_CCPS(),
             new Model64_COOPS_CCPS(16),
+    };
+
+    static final DataModel[] MODELS_JDK15 = new DataModel[]{
             new Model64_CCPS(),
             new Model64_CCPS(16),
     };
 
     @Override
     protected void runWith(Class<?> klass) {
-        for (DataModel model : DATA_MODELS) {
-            out.println("***** " + model.toString());
-            out.println(ClassLayout.parseClass(klass, new HotSpotLayouter(model)).toPrintable());
+        for (DataModel model : MODELS_JDK8) {
+            Layouter l = new HotSpotLayouter(model, 8);
+            out.println("***** " + l);
+            out.println(ClassLayout.parseClass(klass, l).toPrintable());
+        }
+
+        for (DataModel model : MODELS_JDK8) {
+            Layouter l = new HotSpotLayouter(model, 15);
+            out.println("***** " + l);
+            out.println(ClassLayout.parseClass(klass, l).toPrintable());
+        }
+
+        for (DataModel model : MODELS_JDK15) {
+            Layouter l = new HotSpotLayouter(model, 15);
+            out.println("***** " + l);
+            out.println(ClassLayout.parseClass(klass, l).toPrintable());
         }
     }
 

--- a/jol-cli/src/main/java/org/openjdk/jol/operations/StringCompress.java
+++ b/jol-cli/src/main/java/org/openjdk/jol/operations/StringCompress.java
@@ -200,7 +200,7 @@ public class StringCompress implements Operation {
                 }
             } else if (DO_MODE.equalsIgnoreCase("estimates")) {
                 for (DataModel model : DATA_MODELS) {
-                    printLine(data, new HotSpotLayouter(model));
+                    printLine(data, new HotSpotLayouter(model, 8));
                 }
             }
 

--- a/jol-core/src/main/java/org/openjdk/jol/info/ClassData.java
+++ b/jol-core/src/main/java/org/openjdk/jol/info/ClassData.java
@@ -251,18 +251,7 @@ public class ClassData {
         int count = 0;
 
         for (FieldData f : fields) {
-            String simpleName = f.typeClass();
-
-            if (
-                !simpleName.equals("boolean") &&
-                !simpleName.equals("byte") &&
-                !simpleName.equals("short") &&
-                !simpleName.equals("char") &&
-                !simpleName.equals("int") &&
-                !simpleName.equals("float") &&
-                !simpleName.equals("long") &&
-                !simpleName.equals("double")
-            ) {
+            if (!f.isPrimitive()) {
                 count++;
             }
         }

--- a/jol-core/src/main/java/org/openjdk/jol/info/FieldData.java
+++ b/jol-core/src/main/java/org/openjdk/jol/info/FieldData.java
@@ -107,6 +107,22 @@ public class FieldData {
         return type;
     }
 
+    public boolean isPrimitive() {
+        switch (type) {
+            case "boolean":
+            case "byte":
+            case "short":
+            case "char":
+            case "int":
+            case "float":
+            case "long":
+            case "double":
+                return true;
+            default:
+                return false;
+        }
+    }
+
     /**
      * Answers the class for the field holder.
      *

--- a/jol-core/src/test/java/org/openjdk/jol/layouters/HotspotLayouterRealTest.java
+++ b/jol-core/src/test/java/org/openjdk/jol/layouters/HotspotLayouterRealTest.java
@@ -25,17 +25,15 @@ public class HotspotLayouterRealTest {
 
     @Test
     public void testSingleClass() throws Exception {
-        if (getVersion() >= 15) return;
-        tryWith(1, 5);
+        tryWith(1, 5, getVersion());
     }
 
     @Test
     public void testTwoClasses() throws Exception {
-        if (getVersion() >= 15) return;
-        tryWith(2, 5);
+        tryWith(2, 5, getVersion());
     }
 
-    public void tryWith(int hierarchyDepth, int fieldsPerClass) throws Exception {
+    public void tryWith(int hierarchyDepth, int fieldsPerClass, int jdkVersion) throws Exception {
         Random seeder = new Random();
         for (int c = 0; c < ITERATIONS; c++) {
             int seed = seeder.nextInt();
@@ -44,7 +42,7 @@ public class HotspotLayouterRealTest {
             try {
                 ClassLayout actual = ClassLayout.parseClass(cl);
 
-                Map<Layouter, ClassLayout> candidates = candidateLayouts(cl);
+                Map<Layouter, ClassLayout> candidates = candidateLayouts(cl, jdkVersion);
 
                 if (!candidates.containsValue(actual)) {
                     System.out.println(actual.toPrintable());
@@ -60,11 +58,11 @@ public class HotspotLayouterRealTest {
         }
     }
 
-    private Map<Layouter, ClassLayout> candidateLayouts(Class<?> cl) {
+    private Map<Layouter, ClassLayout> candidateLayouts(Class<?> cl, int jdkVersion) {
         ClassData cd = ClassData.parseClass(cl);
         Map<Layouter, ClassLayout> layouts = new HashMap<>();
         for (DataModel model : MODELS) {
-            HotSpotLayouter layouter = new HotSpotLayouter(model);
+            HotSpotLayouter layouter = new HotSpotLayouter(model, jdkVersion);
             layouts.put(layouter, layouter.layout(cd));
         }
         return layouts;

--- a/jol-core/src/test/java/org/openjdk/jol/layouters/LayouterInvariantsTest.java
+++ b/jol-core/src/test/java/org/openjdk/jol/layouters/LayouterInvariantsTest.java
@@ -62,12 +62,27 @@ public class LayouterInvariantsTest {
     }
 
     @Test
-    public void testHotspot() {
+    public void testHotspot_Old() {
         for (int c = 0; c < ITERATIONS; c++) {
             ClassData cd = ClassData.parseClass(CLS[c]);
             try {
                 for (DataModel model : MODELS) {
-                    HotSpotLayouter layouter = new HotSpotLayouter(model);
+                    HotSpotLayouter layouter = new HotSpotLayouter(model, 8);
+                    layouter.layout(cd);
+                }
+            } catch (Exception e) {
+                Assert.fail("Failed. Seed = " + SEEDS[c]);
+            }
+        }
+    }
+
+    @Test
+    public void testHotspot_New() {
+        for (int c = 0; c < ITERATIONS; c++) {
+            ClassData cd = ClassData.parseClass(CLS[c]);
+            try {
+                for (DataModel model : MODELS) {
+                    HotSpotLayouter layouter = new HotSpotLayouter(model, 15);
                     layouter.layout(cd);
                 }
             } catch (Exception e) {

--- a/jol-samples/src/main/java/org/openjdk/jol/samples/JOLSample_10_DataModels.java
+++ b/jol-samples/src/main/java/org/openjdk/jol/samples/JOLSample_10_DataModels.java
@@ -48,13 +48,20 @@ public class JOLSample_10_DataModels {
      * are simulations. You can see the reference sizes are different,
      * depending on VM bitness or mode. The header sizes are also
      * a bit different, see subsequent examples to understand why.
+     *
+     * JDK 15 brought a new layouter, which may pack fields more densely.
+     * JDK 15 also allows to have compressed class pointers without
+     * compressed oops.
      */
 
-    static final DataModel[] MODELS = new DataModel[]{
+    static final DataModel[] MODELS_JDK8 = new DataModel[]{
             new Model32(),
             new Model64(),
             new Model64_COOPS_CCPS(),
             new Model64_COOPS_CCPS(16),
+    };
+
+    static final DataModel[] MODELS_JDK15 = new DataModel[]{
             new Model64_CCPS(),
             new Model64_CCPS(16),
     };
@@ -66,8 +73,20 @@ public class JOLSample_10_DataModels {
             System.out.println(ClassLayout.parseClass(A.class, l).toPrintable());
         }
 
-        for (DataModel model : MODELS) {
-            Layouter l = new HotSpotLayouter(model);
+        for (DataModel model : MODELS_JDK8) {
+            Layouter l = new HotSpotLayouter(model, 8);
+            System.out.println("***** " + l);
+            System.out.println(ClassLayout.parseClass(A.class, l).toPrintable());
+        }
+
+        for (DataModel model : MODELS_JDK8) {
+            Layouter l = new HotSpotLayouter(model, 15);
+            System.out.println("***** " + l);
+            System.out.println(ClassLayout.parseClass(A.class, l).toPrintable());
+        }
+
+        for (DataModel model : MODELS_JDK15) {
+            Layouter l = new HotSpotLayouter(model, 15);
             System.out.println("***** " + l);
             System.out.println(ClassLayout.parseClass(A.class, l).toPrintable());
         }
@@ -75,7 +94,7 @@ public class JOLSample_10_DataModels {
 
     public static class A {
         Object a;
-        Object b;
+        int b;
     }
 
 }

--- a/jol-samples/src/main/java/org/openjdk/jol/samples/JOLSample_10_DataModels.java
+++ b/jol-samples/src/main/java/org/openjdk/jol/samples/JOLSample_10_DataModels.java
@@ -68,14 +68,14 @@ public class JOLSample_10_DataModels {
      *     (since JDK 15, can be enabled even without compressed references)
      */
 
-    static final DataModel[] MODELS_JDK8 = new DataModel[]{
+    private static final DataModel[] MODELS_JDK8 = new DataModel[]{
             new Model32(),
             new Model64(),
             new Model64_COOPS_CCPS(),
             new Model64_COOPS_CCPS(16),
     };
 
-    static final DataModel[] MODELS_JDK15 = new DataModel[]{
+    private static final DataModel[] MODELS_JDK15 = new DataModel[]{
             new Model64_CCPS(),
             new Model64_CCPS(16),
     };


### PR DESCRIPTION
JDK-8237767 added a new layouter. JOL needs to simulate it as well.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902869](https://bugs.openjdk.java.net/browse/CODETOOLS-7902869): JOL: Support JDK 15+ field layouter simulation


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jol pull/14/head:pull/14` \
`$ git checkout pull/14`

Update a local copy of the PR: \
`$ git checkout pull/14` \
`$ git pull https://git.openjdk.java.net/jol pull/14/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 14`

View PR using the GUI difftool: \
`$ git pr show -t 14`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jol/pull/14.diff">https://git.openjdk.java.net/jol/pull/14.diff</a>

</details>
