### PR TITLE
CODETOOLS-7902930: JOL: Bring back GraphWalker visitors

### DIFF
--- a/jol-core/src/main/java/org/openjdk/jol/info/ArrayGraphPathRecord.java
+++ b/jol-core/src/main/java/org/openjdk/jol/info/ArrayGraphPathRecord.java
@@ -39,7 +39,7 @@ final class ArrayGraphPathRecord extends GraphPathRecord {
     }
 
     @Override
-    final String path() {
+    public final String path() {
         if (parent != null) {
             return parent.path() + "[" + idx + "]";
         } else {

--- a/jol-core/src/main/java/org/openjdk/jol/info/FieldGraphPathRecord.java
+++ b/jol-core/src/main/java/org/openjdk/jol/info/FieldGraphPathRecord.java
@@ -38,7 +38,7 @@ final class FieldGraphPathRecord extends GraphPathRecord {
     }
 
     @Override
-    final String path() {
+    public final String path() {
         if (parent != null) {
             return parent.path() + "." + name;
         } else {

--- a/jol-core/src/main/java/org/openjdk/jol/info/GraphPathRecord.java
+++ b/jol-core/src/main/java/org/openjdk/jol/info/GraphPathRecord.java
@@ -31,7 +31,7 @@ import org.openjdk.jol.vm.VM;
  *
  * @author Aleksey Shipilev
  */
-abstract class GraphPathRecord {
+public abstract class GraphPathRecord {
     protected final GraphPathRecord parent;
     private final int depth;
     private final Object obj;
@@ -47,13 +47,13 @@ abstract class GraphPathRecord {
         return obj;
     }
 
-    abstract String path();
+    public abstract String path();
 
-    final Class<?> klass() {
+    public final Class<?> klass() {
         return obj.getClass();
     }
 
-    final long size() {
+    public final long size() {
         if (size == 0) {
             // Object size would not change, fine to compute lazily.
             size = VM.current().sizeOf(obj);


### PR DESCRIPTION
Hey @shipilev First of all: Thanks for this useful library. I wanted to switch from jol 0.10 to 0.15 in one of my projects because of some issues on openJDK 15. I discovered that the ability to register visitors had been removed at some point. The interface `org.openjdk.jol.info.GraphVisitor` is actually still around. I find that feature quite useful as it allows users to compute some custom statistics of the object graph. I tried to use the `GraphLayout` to access the GPRs, but it's all package-private.

It would be nice if we could bring the feature back. Also, if you think the approach is not ideal, we can maybe figure out something else.

Thanks for your time.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902930](https://bugs.openjdk.java.net/browse/CODETOOLS-7902930): JOL: Bring back GraphWalker visitors


### Reviewers
 * @stokito (no known github.com user name / role) ⚠️ Review applies to 0d75043be51321ce8fe87940af51123b8f61c8a4
 * [Aleksey Shipilev](https://openjdk.java.net/census#shade) (@shipilev - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jol pull/15/head:pull/15` \
`$ git checkout pull/15`

Update a local copy of the PR: \
`$ git checkout pull/15` \
`$ git pull https://git.openjdk.java.net/jol pull/15/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 15`

View PR using the GUI difftool: \
`$ git pr show -t 15`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jol/pull/15.diff">https://git.openjdk.java.net/jol/pull/15.diff</a>

</details>
