### PR TITLE
CODETOOLS-7902932: JOL: Update test JDK lists for GHA

### DIFF
--- a/.github/workflows/pre-integration.yml
+++ b/.github/workflows/pre-integration.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        java: [7, 8, 11, 13, 15, 16-ea, 17-ea]
+        java: [7, 8, 11, 16, 17-ea]
         os: [ubuntu-18.04, windows-2019, macos-10.15]
       fail-fast: false
     name: Test JDK ${{ matrix.java }}, ${{ matrix.os }}


### PR DESCRIPTION
Align test JDK lists with the currently released/important JDKs.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7902932](https://bugs.openjdk.java.net/browse/CODETOOLS-7902932): JOL: Update test JDK lists for GHA


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jol pull/17/head:pull/17` \
`$ git checkout pull/17`

Update a local copy of the PR: \
`$ git checkout pull/17` \
`$ git pull https://git.openjdk.java.net/jol pull/17/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17`

View PR using the GUI difftool: \
`$ git pr show -t 17`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jol/pull/17.diff">https://git.openjdk.java.net/jol/pull/17.diff</a>

</details>
