### PR TITLE
make FieldLayout#data() public

### DIFF
--- a/jol-core/src/main/java/org/openjdk/jol/info/FieldLayout.java
+++ b/jol-core/src/main/java/org/openjdk/jol/info/FieldLayout.java
@@ -106,7 +106,7 @@ public class FieldLayout implements Comparable<FieldLayout> {
         }
     }
 
-    FieldData data() {
+    public FieldData data() {
         return f;
     }
 

--- a/jol-core/src/main/java/org/openjdk/jol/info/FieldLayout.java
+++ b/jol-core/src/main/java/org/openjdk/jol/info/FieldLayout.java
@@ -24,6 +24,10 @@
  */
 package org.openjdk.jol.info;
 
+import org.openjdk.jol.util.ObjectUtils;
+
+import java.lang.reflect.Field;
+
 /**
  * Holds the field info with the layout.
  *
@@ -106,7 +110,30 @@ public class FieldLayout implements Comparable<FieldLayout> {
         }
     }
 
-    public FieldData data() {
+    /**
+     * Returns the value of the field for a given instance.
+     *
+     * @param instance  object from which the represented field's value is to be extracted
+     *
+     * @return the value of the represented field
+     */
+    public Object value(Object instance) {
+        if (instance == null) {
+            return null;
+        }
+        return ObjectUtils.value(instance, f.refField());
+    }
+
+    /**
+     * Get original Field.
+     *
+     * @return Field which is represented by the FieldLayout
+     */
+    public Field refField() {
+        return f.refField();
+    }
+
+    FieldData data() {
         return f;
     }
 


### PR DESCRIPTION
Can we have this property public? This is needed for https://github.com/atp-mipt/ljv visualizer: we can use JOL to get object fields in consistent order, but then we also need `FieldData` itself in order to get fields' values

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jol pull/19/head:pull/19` \
`$ git checkout pull/19`

Update a local copy of the PR: \
`$ git checkout pull/19` \
`$ git pull https://git.openjdk.java.net/jol pull/19/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19`

View PR using the GUI difftool: \
`$ git pr show -t 19`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jol/pull/19.diff">https://git.openjdk.java.net/jol/pull/19.diff</a>

</details>
