### PR TITLE
CODETOOLS-7903075: JOL: Incorrect ClassLayout header/loss calculation for arrays

### DIFF
--- a/jol-core/src/main/java/org/openjdk/jol/info/ClassLayout.java
+++ b/jol-core/src/main/java/org/openjdk/jol/info/ClassLayout.java
@@ -103,6 +103,7 @@ public class ClassLayout {
     }
 
     private final ClassData classData;
+    private final boolean isArray;
     private final SortedSet<FieldLayout> fields;
     private final DataModel model;
     private final long size;
@@ -118,6 +119,7 @@ public class ClassLayout {
         this.lossesInternal = lossesInternal;
         this.lossesExternal = lossesExternal;
         this.lossesTotal = lossesTotal;
+        this.isArray = classData.isArray();
     }
 
     /**
@@ -135,7 +137,7 @@ public class ClassLayout {
             checkInvariants(fields, instanceSize);
         }
         // calculate loses
-        long next = model.headerSize();
+        long next = classData.isArray() ? model.arrayHeaderSize() : model.headerSize();
         long internal = 0;
         for (FieldLayout fl : fields) {
             if (fl.offset() > next) {
@@ -188,7 +190,7 @@ public class ClassLayout {
      * @return header size
      */
     public int headerSize() {
-        return model.headerSize();
+        return isArray ? model.arrayHeaderSize() : model.headerSize();
     }
 
     /**


### PR DESCRIPTION
See the bug report.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7903075](https://bugs.openjdk.java.net/browse/CODETOOLS-7903075): JOL: Incorrect ClassLayout header/loss calculation for arrays


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jol pull/20/head:pull/20` \
`$ git checkout pull/20`

Update a local copy of the PR: \
`$ git checkout pull/20` \
`$ git pull https://git.openjdk.java.net/jol pull/20/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20`

View PR using the GUI difftool: \
`$ git pr show -t 20`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jol/pull/20.diff">https://git.openjdk.java.net/jol/pull/20.diff</a>

</details>
