### PR TITLE
CODETOOLS-7903119: JOL: Experimental support for Lilliput

### DIFF
--- a/jol-core/src/main/java/org/openjdk/jol/info/ClassLayout.java
+++ b/jol-core/src/main/java/org/openjdk/jol/info/ClassLayout.java
@@ -309,10 +309,12 @@ public class ClassLayout {
             VirtualMachine vm = VM.current();
             if (markSize == 8) {
                 long mark = vm.getLong(instance, markOffset);
-                markStr = toHex(mark) + " " + parseMarkWord(mark);
+                String decoded = (classSize > 0) ? parseMarkWord(mark) : "(Lilliput)";
+                markStr = toHex(mark) + " " + decoded;
             } else if (markSize == 4) {
                 int mark = vm.getInt(instance, markOffset);
-                markStr = toHex(mark) + " " + parseMarkWord(mark);
+                String decoded = (classSize > 0) ? parseMarkWord(mark) : "(Lilliput)";
+                markStr = toHex(mark) + " " + decoded;
             }
 
             if (classSize == 8) {
@@ -327,7 +329,9 @@ public class ClassLayout {
         }
 
         pw.printf(format, markOffset, markSize, "", MSG_MARK_WORD, markStr);
-        pw.printf(format, classOffset, classSize, "", MSG_CLASS_WORD, classStr);
+        if (classSize > 0) {
+            pw.printf(format, classOffset, classSize, "", MSG_CLASS_WORD, classStr);
+        }
         if (classData.isArray()) {
             pw.printf(format, arrOffset, arrSize, "", MSG_ARR_LEN, arrLenStr);
         }

--- a/jol-core/src/main/java/org/openjdk/jol/vm/Experiments.java
+++ b/jol-core/src/main/java/org/openjdk/jol/vm/Experiments.java
@@ -35,6 +35,10 @@ class Experiments {
         public boolean b1;
     }
 
+    public static class MyObject0 {
+
+    }
+
     public static class MyObject1 {
 
     }


### PR DESCRIPTION
Project Lilliput aims to reduce the size of the object header. JOL can support that project by detecting the Lilliput VM and printing out object internals more precisely. 

Sample output on JDK 19+:

```
# Running 64-bit HotSpot VM.
# Using compressed oop with 3-bit shift.
# Using compressed klass with 3-bit shift.
# Objects are 8 bytes aligned.
#                       ref, bool, byte, char, shrt,  int,  flt,  lng,  dbl
# Field sizes:            4,    1,    1,    2,    2,    4,    4,    8,    8
# Array element sizes:    4,    1,    1,    2,    2,    4,    4,    8,    8
# Array base offsets:    16,   16,   16,   16,   16,   16,   16,   16,   16

[B object internals:
OFF  SZ   TYPE DESCRIPTION               VALUE
  0   8        (object header: mark)     0x0000000000000001 (non-biasable; age: 0)
  8   4        (object header: class)    0x00001ea0
 12   4        (array length)            5
 16   5   byte [B.<elements>             N/A
 21   3        (object alignment gap)    
Instance size: 24 bytes
Space losses: 0 bytes internal + 3 bytes external = 3 bytes total
```

Sample output on current Lilliput:

```
# Running 64-bit HotSpot VM.
# Lilliput VM detected (experimental).
# Using compressed oop with 3-bit shift.
# Using compressed klass with 3-bit shift.
# Objects are 8 bytes aligned.
#                       ref, bool, byte, char, shrt,  int,  flt,  lng,  dbl
# Field sizes:            4,    1,    1,    2,    2,    4,    4,    8,    8
# Array element sizes:    4,    1,    1,    2,    2,    4,    4,    8,    8
# Array base offsets:    16,   16,   16,   16,   16,   16,   16,   16,   16

[B object internals:
OFF  SZ   TYPE DESCRIPTION               VALUE
  0   8        (object header: mark)     0x0000001200000001 (Lilliput)
  8   4        (array length)            4
 12   4        (alignment/padding gap)   
 16   4   byte [B.<elements>             N/A
 20   4        (object alignment gap)    
Instance size: 24 bytes
Space losses: 4 bytes internal + 4 bytes external = 8 bytes total
```

Sample run on Lilliput + https://github.com/openjdk/lilliput/pull/41:

```
# Running 64-bit HotSpot VM.
# Lilliput VM detected (experimental).
# Using compressed oop with 3-bit shift.
# Using compressed klass with 3-bit shift.
# Objects are 8 bytes aligned.
#                       ref, bool, byte, char, shrt,  int,  flt,  lng,  dbl
# Field sizes:            4,    1,    1,    2,    2,    4,    4,    8,    8
# Array element sizes:    4,    1,    1,    2,    2,    4,    4,    8,    8
# Array base offsets:    12,   12,   12,   12,   12,   12,   12,   16,   16

[B object internals:
OFF  SZ   TYPE DESCRIPTION               VALUE
  0   8        (object header: mark)     0x0000001200000001 (Lilliput)
  8   4        (array length)            4
 12   4   byte [B.<elements>             N/A
Instance size: 16 bytes
Space losses: 0 bytes internal + 0 bytes external = 0 bytes total
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed

### Issue
 * [CODETOOLS-7903119](https://bugs.openjdk.java.net/browse/CODETOOLS-7903119): JOL: Experimental support for Lilliput


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.java.net/jol pull/22/head:pull/22` \
`$ git checkout pull/22`

Update a local copy of the PR: \
`$ git checkout pull/22` \
`$ git pull https://git.openjdk.java.net/jol pull/22/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 22`

View PR using the GUI difftool: \
`$ git pr show -t 22`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.java.net/jol/pull/22.diff">https://git.openjdk.java.net/jol/pull/22.diff</a>

</details>
