### PR TITLE
CODETOOLS-7903235: JOL: Improve GHA triggers

### DIFF
--- a/.github/workflows/pre-integration.yml
+++ b/.github/workflows/pre-integration.yml
@@ -1,8 +1,10 @@
 name: JOL Pre-Integration Tests
 
 on:
-  pull_request:
-    types: [opened, reopened, ready_for_review, synchronize]
+  push:
+    branches-ignore:
+      - master
+      - pr/*
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
GHA workflows need to have a push-based trigger instead of pull_request one, in order to comply with current scheme of running actions in private forks. 