### PR TITLE
CODETOOLS-7903262: JOL: GraphStatsWalker counts array elements incorrectly

### DIFF
--- a/jol-core/src/main/java/org/openjdk/jol/info/GraphStatsWalker.java
+++ b/jol-core/src/main/java/org/openjdk/jol/info/GraphStatsWalker.java
@@ -67,6 +67,7 @@ public class GraphStatsWalker extends AbstractGraphWalker {
 
                 for (Object e : (Object[]) o) {
                     if (e != null && visited.add(e)) {
+                        data.addRecord(vm.sizeOf(e));
                         s.push(e);
                     }
                 }

--- a/jol-core/src/test/java/org/openjdk/jol/info/GraphStatsTest.java
+++ b/jol-core/src/test/java/org/openjdk/jol/info/GraphStatsTest.java
@@ -23,6 +23,14 @@ public class GraphStatsTest {
         public D(D d) { this.d = d; }
     }
 
+    static class E {
+        private final A[] as;
+
+        E() {
+            as = new A[] { new A() };
+        }
+    }
+
     @Test
     public void basicCounts() {
         A a = new A();
@@ -85,4 +93,14 @@ public class GraphStatsTest {
         }
     }
 
+    @Test
+    public void layoutAndStatsAccordance() {
+        E e = new E();
+
+        GraphLayout layout = GraphLayout.parseInstance(e);
+        GraphStats stats = GraphStats.parseInstance(e);
+
+        Assert.assertEquals(layout.totalSize(), stats.totalSize());
+        Assert.assertEquals(layout.totalCount(), stats.totalCount());
+    }
 }

--- a/jol-core/src/test/java/org/openjdk/jol/info/GraphStatsTest.java
+++ b/jol-core/src/test/java/org/openjdk/jol/info/GraphStatsTest.java
@@ -94,7 +94,7 @@ public class GraphStatsTest {
     }
 
     @Test
-    public void layoutAndStatsAccordance() {
+    public void layoutAndStatsMatch() {
         E e = new E();
 
         GraphLayout layout = GraphLayout.parseInstance(e);


### PR DESCRIPTION
#### Observed behavior
Current `GraphStatsWalker` implementation does not count size and quantity of objects directly contained in arrays.

#### Desired behavior
The `totalSize()` and `totalCount()` methods of a `GraphStats` instance should return the same values as the ones of `GraphLayout` instance built for the same object.

#### Additional info
There is a [simple unit test](https://gist.github.com/Toparvion/adec9052ad23e85e54d72b5bfb5a1aa3) that can be used to reproduce current behavior without checking out the fix branch.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903262](https://bugs.openjdk.org/browse/CODETOOLS-7903262): JOL: GraphStatsWalker counts array elements incorrectly


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jol pull/33/head:pull/33` \
`$ git checkout pull/33`

Update a local copy of the PR: \
`$ git checkout pull/33` \
`$ git pull https://git.openjdk.org/jol pull/33/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 33`

View PR using the GUI difftool: \
`$ git pr show -t 33`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jol/pull/33.diff">https://git.openjdk.org/jol/pull/33.diff</a>

</details>
