### PR TITLE
CODETOOLS-7903352: JOL: Drop support for JDK 7

### DIFF
--- a/.github/workflows/pre-integration.yml
+++ b/.github/workflows/pre-integration.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        java: [7, 8, 11, 17, 19-ea]
+        java: [8, 11, 17, 19-ea]
         os: [ubuntu-20.04, windows-2022, macos-11]
       fail-fast: false
     name: Test JDK ${{ matrix.java }}, ${{ matrix.os }}

--- a/jol-cli/src/main/java/org/openjdk/jol/operations/ClasspathedOperation.java
+++ b/jol-cli/src/main/java/org/openjdk/jol/operations/ClasspathedOperation.java
@@ -119,13 +119,13 @@ public abstract class ClasspathedOperation implements Operation {
 
     private static Object makeDefaultValue(Class<?> type) {
         if (type == boolean.class || type == Boolean.class)   return Boolean.FALSE;
-        if (type == byte.class    || type == Byte.class)      return Byte.valueOf((byte) 0);
-        if (type == short.class   || type == Short.class)     return Short.valueOf((short)0);
-        if (type == char.class    || type == Character.class) return Character.valueOf((char)0);
-        if (type == int.class     || type == Integer.class)   return Integer.valueOf(0);
-        if (type == float.class   || type == Float.class)     return Float.valueOf(0f);
-        if (type == long.class    || type == Long.class)      return Long.valueOf(0);
-        if (type == double.class  || type == Double.class)    return Double.valueOf(0d);
+        if (type == byte.class    || type == Byte.class)      return (byte) 0;
+        if (type == short.class   || type == Short.class)     return (short) 0;
+        if (type == char.class    || type == Character.class) return (char) 0;
+        if (type == int.class     || type == Integer.class)   return 0;
+        if (type == float.class   || type == Float.class)     return 0F;
+        if (type == long.class    || type == Long.class)      return 0L;
+        if (type == double.class  || type == Double.class)    return 0D;
         return null;
     }
 

--- a/jol-cli/src/main/java/org/openjdk/jol/operations/HeapDumpStats.java
+++ b/jol-cli/src/main/java/org/openjdk/jol/operations/HeapDumpStats.java
@@ -78,12 +78,7 @@ public class HeapDumpStats implements Operation {
         }
 
         List<String> sorted = new ArrayList<>(sizes.keys());
-        Collections.sort(sorted, new Comparator<String>() {
-            @Override
-            public int compare(String o1, String o2) {
-                return Long.compare(sizes.count(o2), sizes.count(o1));
-            }
-        });
+        sorted.sort((o1, o2) -> Long.compare(sizes.count(o2), sizes.count(o1)));
 
         final int printFirst = Integer.getInteger("printFirst", 30);
 

--- a/jol-cli/src/main/java/org/openjdk/jol/operations/ObjectShapes.java
+++ b/jol-cli/src/main/java/org/openjdk/jol/operations/ObjectShapes.java
@@ -64,20 +64,10 @@ public class ObjectShapes implements Operation {
 
         for (final String arg : args) {
             if (arg.endsWith(".jar")) {
-                cs.submit(new Callable<Multiset<String>>() {
-                    @Override
-                    public Multiset<String> call() throws Exception {
-                        return processJAR(arg);
-                    }
-                });
+                cs.submit(() -> processJAR(arg));
             }
             if (arg.endsWith(".dump") || arg.endsWith("hprof") || arg.endsWith("hprof.gz")) {
-                cs.submit(new Callable<Multiset<String>>() {
-                    @Override
-                    public Multiset<String> call() throws Exception {
-                        return processHeapDump(arg);
-                    }
-                });
+                cs.submit(() -> processHeapDump(arg));
             }
         }
 

--- a/jol-core/src/main/java/org/openjdk/jol/info/ClassData.java
+++ b/jol-core/src/main/java/org/openjdk/jol/info/ClassData.java
@@ -30,6 +30,7 @@ import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 import org.openjdk.jol.util.ClassUtils;
 import org.openjdk.jol.vm.ContendedSupport;
@@ -398,16 +399,16 @@ public class ClassData {
         if (length != classData.length) {
             return false;
         }
-        if (arrayComponentKlass != null ? !arrayComponentKlass.equals(classData.arrayComponentKlass) : classData.arrayComponentKlass != null) {
+        if (!Objects.equals(arrayComponentKlass, classData.arrayComponentKlass)) {
             return false;
         }
-        if (arrayKlass != null ? !arrayKlass.equals(classData.arrayKlass) : classData.arrayKlass != null) {
+        if (!Objects.equals(arrayKlass, classData.arrayKlass)) {
             return false;
         }
-        if (classNames != null ? !classNames.equals(classData.classNames) : classData.classNames != null) {
+        if (!Objects.equals(classNames, classData.classNames)) {
             return false;
         }
-        if (fields != null ? !fields.equals(classData.fields) : classData.fields != null) {
+        if (!Objects.equals(fields, classData.fields)) {
             return false;
         }
 

--- a/jol-core/src/main/java/org/openjdk/jol/info/FieldLayout.java
+++ b/jol-core/src/main/java/org/openjdk/jol/info/FieldLayout.java
@@ -129,7 +129,7 @@ public class FieldLayout implements Comparable<FieldLayout> {
 
     @Override
     public int compareTo(FieldLayout o) {
-        return Long.valueOf(offset).compareTo(o.offset);
+        return Long.compare(offset, o.offset);
     }
 
     @Override

--- a/jol-core/src/main/java/org/openjdk/jol/info/GraphLayout.java
+++ b/jol-core/src/main/java/org/openjdk/jol/info/GraphLayout.java
@@ -201,12 +201,7 @@ public class GraphLayout {
         }
 
         synchronized (this) {
-            classes = new TreeSet<>(new Comparator<Class<?>>() {
-                @Override
-                public int compare(Class<?> o1, Class<?> o2) {
-                    return o1.getName().compareTo(o2.getName());
-                }
-            });
+            classes = new TreeSet<>(Comparator.comparing(Class::getName));
             classSizes = new Multiset<>();
             classCounts = new Multiset<>();
 

--- a/jol-core/src/main/java/org/openjdk/jol/layouters/HotSpotLayouter.java
+++ b/jol-core/src/main/java/org/openjdk/jol/layouters/HotSpotLayouter.java
@@ -169,7 +169,7 @@ public class HotSpotLayouter implements Layouter {
             for (FieldAllocationType atype : FieldAllocationType.values()) {
                 fieldsAllocationCount.put(atype, 0);
                 nextOffset.put(atype,  0);
-                spaceOffset.put(atype, new ArrayDeque<Integer>());
+                spaceOffset.put(atype, new ArrayDeque<>());
             }
             allocationTypeSizes.put(OOP,    model.sizeOf("oop"));
             allocationTypeSizes.put(BYTE,   model.sizeOf("byte"));
@@ -209,11 +209,11 @@ public class HotSpotLayouter implements Layouter {
             // The packing code below relies on these counts to determine if some field
             // can be squeezed into the alignment gap. Contended fields are obviously
             // exempt from that.
-            int doubleCount = fieldsAllocationCount.get(DOUBLE) - (facContended.containsKey(DOUBLE) ? facContended.get(DOUBLE) : 0);
-            int wordCount   = fieldsAllocationCount.get(WORD)   - (facContended.containsKey(WORD)   ? facContended.get(WORD)   : 0);
-            int shortCount  = fieldsAllocationCount.get(SHORT)  - (facContended.containsKey(SHORT)  ? facContended.get(SHORT)  : 0);
-            int byteCount   = fieldsAllocationCount.get(BYTE)   - (facContended.containsKey(BYTE)   ? facContended.get(BYTE)   : 0);
-            int oopCount    = fieldsAllocationCount.get(OOP)    - (facContended.containsKey(OOP)    ? facContended.get(OOP)    : 0);
+            int doubleCount = fieldsAllocationCount.get(DOUBLE) - (facContended.getOrDefault(DOUBLE, 0));
+            int wordCount   = fieldsAllocationCount.get(WORD)   - (facContended.getOrDefault(WORD, 0));
+            int shortCount  = fieldsAllocationCount.get(SHORT)  - (facContended.getOrDefault(SHORT, 0));
+            int byteCount   = fieldsAllocationCount.get(BYTE)   - (facContended.getOrDefault(BYTE, 0));
+            int oopCount    = fieldsAllocationCount.get(OOP)    - (facContended.getOrDefault(OOP, 0));
 
             int firstOopOffset = 0; // will be set for first oop field
 

--- a/jol-core/src/main/java/org/openjdk/jol/vm/HotspotUnsafe.java
+++ b/jol-core/src/main/java/org/openjdk/jol/vm/HotspotUnsafe.java
@@ -85,13 +85,7 @@ class HotspotUnsafe implements VirtualMachine {
     private Object mfoUnsafe;
     private Method mfoMethod;
 
-    private final ThreadLocal<Object[]> BUFFERS = new ThreadLocal<Object[]>() {
-        @Override
-        protected Object[] initialValue() {
-            return new Object[1];
-        }
-    };
-
+    private final ThreadLocal<Object[]> BUFFERS = ThreadLocal.withInitial(() -> new Object[1]);
 
     HotspotUnsafe(Unsafe u, Instrumentation inst, UniverseData saDetails) {
         U = u;

--- a/jol-core/src/main/java/org/openjdk/jol/vm/VM.java
+++ b/jol-core/src/main/java/org/openjdk/jol/vm/VM.java
@@ -36,20 +36,15 @@ import java.security.PrivilegedAction;
 public class VM {
 
     private static Unsafe tryUnsafe() {
-        return AccessController.doPrivileged(
-                new PrivilegedAction<Unsafe>() {
-                    @Override
-                    public Unsafe run() {
-                        try {
-                            Field unsafe = Unsafe.class.getDeclaredField("theUnsafe");
-                            unsafe.setAccessible(true);
-                            return (Unsafe) unsafe.get(null);
-                        } catch (NoSuchFieldException | IllegalAccessException e) {
-                            throw new IllegalStateException(e);
-                        }
-                    }
-                }
-        );
+        return AccessController.doPrivileged((PrivilegedAction<Unsafe>) () -> {
+            try {
+                Field unsafe = Unsafe.class.getDeclaredField("theUnsafe");
+                unsafe.setAccessible(true);
+                return (Unsafe) unsafe.get(null);
+            } catch (NoSuchFieldException | IllegalAccessException e) {
+                throw new IllegalStateException(e);
+            }
+        });
     }
 
     private static VirtualMachine INSTANCE;

--- a/jol-core/src/main/java/org/openjdk/jol/vm/sa/AttachMain.java
+++ b/jol-core/src/main/java/org/openjdk/jol/vm/sa/AttachMain.java
@@ -66,18 +66,15 @@ class AttachMain {
 
             final Object agent = hotspotAgent;
             Future<?> future = Executors.newCachedThreadPool(new MyThreadFactory())
-                    .submit(new Callable<Object>() {
-                                @Override
-                                public Object call() {
-                                    try {
-                                        // Attach to the caller process as Hotspot agent
-                                        attachMethod.invoke(agent, (int) request.getProcessId());
-                                        return ClassUtils.loadClass(VM_CLASSNAME).getMethod("getVM").invoke(null);
-                                    } catch (Exception t) {
-                                        throw new RuntimeException(t);
-                                    }
-                                }
-                            }
+                    .submit(() -> {
+                        try {
+                            // Attach to the caller process as Hotspot agent
+                            attachMethod.invoke(agent, (int) request.getProcessId());
+                            return ClassUtils.loadClass(VM_CLASSNAME).getMethod("getVM").invoke(null);
+                        } catch (Exception t) {
+                            throw new RuntimeException(t);
+                        }
+                    }
                     );
 
             Object vm = future.get(request.getTimeout(), TimeUnit.MILLISECONDS);

--- a/jol-samples/src/main/java/org/openjdk/jol/samples/JOLSample_14_FatLocking.java
+++ b/jol-samples/src/main/java/org/openjdk/jol/samples/JOLSample_14_FatLocking.java
@@ -72,15 +72,12 @@ public class JOLSample_14_FatLocking {
         out.println("**** Fresh object");
         out.println(layout.toPrintable());
 
-        Thread t = new Thread(new Runnable() {
-            @Override
-            public void run() {
-                synchronized (a) {
-                    try {
-                        TimeUnit.SECONDS.sleep(10);
-                    } catch (InterruptedException e) {
-                        return;
-                    }
+        Thread t = new Thread(() -> {
+            synchronized (a) {
+                try {
+                    TimeUnit.SECONDS.sleep(10);
+                } catch (InterruptedException e) {
+                    // Do nothing
                 }
             }
         });

--- a/jol-samples/src/main/java/org/openjdk/jol/samples/JOLSample_27_Colocation.java
+++ b/jol-samples/src/main/java/org/openjdk/jol/samples/JOLSample_27_Colocation.java
@@ -97,13 +97,10 @@ public class JOLSample_27_Colocation {
     private static void addElements(final int count, final Map<Object, Object> chm) throws InterruptedException {
         ExecutorService pool = Executors.newCachedThreadPool();
 
-        Runnable task = new Runnable() {
-            @Override
-            public void run() {
-                for (int c = 0; c < count; c++) {
-                    Object o = new Object();
-                    chm.put(o, o);
-                }
+        Runnable task = () -> {
+            for (int c = 0; c < count; c++) {
+                Object o = new Object();
+                chm.put(o, o);
             }
         };
 

--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@ questions.
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <jol.target>1.7</jol.target>
+        <jol.target>1.8</jol.target>
     </properties>
 
 </project>


### PR DESCRIPTION
Head JDK 20-ea does not support building with -source/target 7 anymore. JDK 7 is very old and unlikely to be used widely. We can bump the minimal version to JDK 8 to get... ahem... all the new features that release brings!

If you have a strong opinion that we should *not* drop JDK 7 support, please speak up soon.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903352](https://bugs.openjdk.org/browse/CODETOOLS-7903352): JOL: Drop support for JDK 7


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jol pull/34/head:pull/34` \
`$ git checkout pull/34`

Update a local copy of the PR: \
`$ git checkout pull/34` \
`$ git pull https://git.openjdk.org/jol pull/34/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 34`

View PR using the GUI difftool: \
`$ git pr show -t 34`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jol/pull/34.diff">https://git.openjdk.org/jol/pull/34.diff</a>

</details>
