### PR TITLE
CODETOOLS-7903364: JOL: Fix support for modern SA

### DIFF
--- a/jol-core/src/main/java/org/openjdk/jol/vm/HotspotUnsafe.java
+++ b/jol-core/src/main/java/org/openjdk/jol/vm/HotspotUnsafe.java
@@ -111,7 +111,7 @@ class HotspotUnsafe implements VirtualMachine {
         narrowKlassBase = saDetails.getNarrowKlassBase();
 
         sizes = new Sizes(this);
-        lilliputVM = guessLilliput(objectHeaderSize);
+        lilliputVM = guessLilliput(addressSize);
     }
 
     HotspotUnsafe(Unsafe u, Instrumentation inst) {

--- a/jol-core/src/main/java/org/openjdk/jol/vm/sa/Constants.java
+++ b/jol-core/src/main/java/org/openjdk/jol/vm/sa/Constants.java
@@ -28,6 +28,8 @@ class Constants {
 
     static final String HOTSPOT_AGENT_CLASSNAME = "sun.jvm.hotspot.HotSpotAgent";
     static final String VM_CLASSNAME = "sun.jvm.hotspot.runtime.VM";
+    static final String COMP_OOPS_CLASSNAME = "sun.jvm.hotspot.oops.CompressedOops";
+    static final String COMP_KLASS_CLASSNAME = "sun.jvm.hotspot.oops.CompressedKlassPointers";
     static final String UNIVERSE_CLASSNAME = "sun.jvm.hotspot.memory.Universe";
 
     static final String SKIP_HOTSPOT_SA_ATTACH_FLAG = "jol.skipHotspotSAAttach";

--- a/jol-core/src/main/java/org/openjdk/jol/vm/sa/ServiceabilityAgentSupport.java
+++ b/jol-core/src/main/java/org/openjdk/jol/vm/sa/ServiceabilityAgentSupport.java
@@ -271,6 +271,7 @@ public class ServiceabilityAgentSupport {
                 args.add("--add-exports"); args.add("jdk.hotspot.agent/sun.jvm.hotspot=ALL-UNNAMED");
                 args.add("--add-exports"); args.add("jdk.hotspot.agent/sun.jvm.hotspot.runtime=ALL-UNNAMED");
                 args.add("--add-exports"); args.add("jdk.hotspot.agent/sun.jvm.hotspot.memory=ALL-UNNAMED");
+                args.add("--add-exports"); args.add("jdk.hotspot.agent/sun.jvm.hotspot.oops=ALL-UNNAMED");
                 break;
             default:
                 throw new IllegalStateException("Unhandled style: " + style);


### PR DESCRIPTION
SA shuffled a few things around in newer JDKs, we need to update JOL support to match it.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903364](https://bugs.openjdk.org/browse/CODETOOLS-7903364): JOL: Fix support for modern SA


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jol pull/36/head:pull/36` \
`$ git checkout pull/36`

Update a local copy of the PR: \
`$ git checkout pull/36` \
`$ git pull https://git.openjdk.org/jol pull/36/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 36`

View PR using the GUI difftool: \
`$ git pr show -t 36`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jol/pull/36.diff">https://git.openjdk.org/jol/pull/36.diff</a>

</details>
