### PR TITLE
7903366: JOL: Clean up VM configuration messages

### DIFF
--- a/jol-core/src/main/java/org/openjdk/jol/vm/HotspotUnsafe.java
+++ b/jol-core/src/main/java/org/openjdk/jol/vm/HotspotUnsafe.java
@@ -306,8 +306,10 @@ class HotspotUnsafe implements VirtualMachine {
             if (narrowOopBase != 0) {
                 out.print(" and " + formatAddressAsHexByAddressSize(narrowOopBase) + " base");
             }
+        } else if (addressSize == 4){
+            out.print("not needed");
         } else {
-            out.print("not enabled");
+            out.print("disabled");
         }
         out.println();
 
@@ -317,8 +319,10 @@ class HotspotUnsafe implements VirtualMachine {
             if (narrowKlassBase != 0) {
                 out.print(" and " + formatAddressAsHexByAddressSize(narrowKlassBase) + " base");
             }
+        } else if (addressSize == 4) {
+            out.print("not needed");
         } else {
-            out.print("not enabled");
+            out.print("disabled");
         }
         out.println();
 
@@ -686,7 +690,7 @@ class HotspotUnsafe implements VirtualMachine {
     }
 
     private String formatAddressAsHexByAddressSize(long address) {
-        return "0x" + String.format("%" + (addressSize * 2) + "s",
+        return "0x" + String.format("%s",
                 Long.toHexString(address).toUpperCase()).replace(' ', '0');
     }
 

--- a/jol-core/src/main/java/org/openjdk/jol/vm/HotspotUnsafe.java
+++ b/jol-core/src/main/java/org/openjdk/jol/vm/HotspotUnsafe.java
@@ -294,37 +294,41 @@ class HotspotUnsafe implements VirtualMachine {
         StringWriter sw = new StringWriter();
         PrintWriter out = new PrintWriter(sw);
 
-        out.println("# Running " + (addressSize * 8) + "-bit HotSpot VM.");
+        out.println("# VM mode: " + (addressSize * 8) + " bits");
 
         if (lilliputVM) {
-            out.println("# Lilliput VM detected (experimental).");
+            out.println("# Lilliput VM detected (experimental)");
         }
 
+        out.print("# Compressed references (oops): ");
         if (compressedOopsEnabled) {
+            out.print(narrowOopShift + "-bit shift");
             if (narrowOopBase != 0) {
-                out.println("# Using compressed oop with " +
-                        formatAddressAsHexByAddressSize(narrowOopBase) + " base address and " +
-                        narrowOopShift + "-bit shift.");
-            } else {
-                out.println("# Using compressed oop with " + narrowOopShift + "-bit shift.");
+                out.print(" and " + formatAddressAsHexByAddressSize(narrowOopBase) + " base");
             }
+        } else {
+            out.print("not enabled");
         }
+        out.println();
+
+        out.print("# Compressed class pointers: ");
         if (compressedKlassOopsEnabled) {
+            out.print(narrowKlassShift + "-bit shift");
             if (narrowKlassBase != 0) {
-                out.println("# Using compressed klass with " +
-                        formatAddressAsHexByAddressSize(narrowKlassBase) + " base address and " +
-                        narrowKlassShift + "-bit shift.");
-            } else {
-                out.println("# Using compressed klass with " + narrowKlassShift + "-bit shift.");
+                out.print(" and " + formatAddressAsHexByAddressSize(narrowKlassBase) + " base");
             }
+        } else {
+            out.print("not enabled");
         }
-        if (!isAccurate && (compressedOopsEnabled || compressedKlassOopsEnabled)) {
+        out.println();
+
+        if (addressSize != 4 && !isAccurate && (compressedOopsEnabled || compressedKlassOopsEnabled)) {
             out.println("# WARNING | Compressed references base/shifts are guessed by the experiment!");
             out.println("# WARNING | Therefore, computed addresses are just guesses, and ARE NOT RELIABLE.");
             out.println("# WARNING | Make sure to attach Serviceability Agent to get the reliable addresses.");
         }
 
-        out.println("# Objects are " + objectAlignment + " bytes aligned.");
+        out.println("# Object alignment: " + objectAlignment + " bytes");
 
         out.printf("# %-20s %4s, %4s, %4s, %4s, %4s, %4s, %4s, %4s, %4s%n",
                 "",


### PR DESCRIPTION
We can be a little more clean with VM configuration messages.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903366](https://bugs.openjdk.org/browse/CODETOOLS-7903366): JOL: Clean up VM configuration messages


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jol pull/37/head:pull/37` \
`$ git checkout pull/37`

Update a local copy of the PR: \
`$ git checkout pull/37` \
`$ git pull https://git.openjdk.org/jol pull/37/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 37`

View PR using the GUI difftool: \
`$ git pr show -t 37`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jol/pull/37.diff">https://git.openjdk.org/jol/pull/37.diff</a>

</details>
