### PR TITLE
7903410: JOL: Extend "estimate" to heap dumps and Lilliput

### DIFF
--- a/jol-cli/src/main/java/org/openjdk/jol/Main.java
+++ b/jol-cli/src/main/java/org/openjdk/jol/Main.java
@@ -43,6 +43,7 @@ public class Main {
         registerOperation(new ObjectShapes());
         registerOperation(new StringCompress());
         registerOperation(new HeapDumpStats());
+        registerOperation(new HeapDumpEstimates());
     }
 
     private static void registerOperation(Operation op) {

--- a/jol-cli/src/main/java/org/openjdk/jol/operations/EstimatedModels.java
+++ b/jol-cli/src/main/java/org/openjdk/jol/operations/EstimatedModels.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2023, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jol.operations;
+
+import org.openjdk.jol.datamodel.*;
+import org.openjdk.jol.layouters.RawLayouter;
+
+public class EstimatedModels {
+
+    static final DataModel[] MODELS_JDK8 = new DataModel[]{
+            new Model32(),
+            new Model64(),
+            new Model64_COOPS_CCPS(),
+            new Model64_COOPS_CCPS(16),
+    };
+
+    static final DataModel[] MODELS_JDK15 = new DataModel[]{
+            new Model64_CCPS(),
+            new Model64_CCPS(16),
+    };
+
+    static final DataModel[] MODELS_LILLIPUT = new DataModel[]{
+            new Model64_Lilliput(false, 8),
+            new Model64_Lilliput(false, 16),
+            new Model64_Lilliput(true, 8),
+            new Model64_Lilliput(true, 16),
+    };
+
+}

--- a/jol-cli/src/main/java/org/openjdk/jol/operations/EstimatedModels.java
+++ b/jol-cli/src/main/java/org/openjdk/jol/operations/EstimatedModels.java
@@ -42,10 +42,12 @@ public class EstimatedModels {
     };
 
     static final DataModel[] MODELS_LILLIPUT = new DataModel[]{
-            new Model64_Lilliput(false, 8),
-            new Model64_Lilliput(false, 16),
-            new Model64_Lilliput(true, 8),
-            new Model64_Lilliput(true, 16),
+            new Model64_Lilliput(false, 8, false),
+            new Model64_Lilliput(true, 8, false),
+            new Model64_Lilliput(true, 16, false),
+            new Model64_Lilliput(false, 8, true),
+            new Model64_Lilliput(true, 8, true),
+            new Model64_Lilliput(true, 16, true),
     };
 
 }

--- a/jol-cli/src/main/java/org/openjdk/jol/operations/HeapDumpEstimates.java
+++ b/jol-cli/src/main/java/org/openjdk/jol/operations/HeapDumpEstimates.java
@@ -60,23 +60,17 @@ public class HeapDumpEstimates implements Operation {
         String path = args[0];
 
         out.println("Heap Dump: " + path);
+        out.println();
 
         HeapDumpReader reader = new HeapDumpReader(new File(path));
         Multiset<ClassData> data = reader.parse();
 
         long rawSize = 0;
-        long rawCount = 0;
         {
             RawLayouter rawLayouter = new RawLayouter(new Model32());
             for (ClassData cd : data.keys()) {
                 rawSize += rawLayouter.layout(cd).instanceSize() * data.count(cd);
-                rawCount += data.count(cd);
             }
-
-            out.println("***** User data");
-            out.printf("  Total data size: %d bytes%n", rawSize);
-            out.printf("  Object count: %d%n", rawCount);
-            out.println();
         }
 
         for (DataModel model : EstimatedModels.MODELS_JDK8) {
@@ -106,8 +100,9 @@ public class HeapDumpEstimates implements Operation {
         for (ClassData cd : data.keys()) {
             size += layouter.layout(cd).instanceSize() * data.count(cd);
         }
+        out.printf("  Total data size:   %d bytes%n", rawSize);
         out.printf("  Total object size: %d bytes%n", size);
-        out.printf("  Object overhead: %.2f%%%n", (size - rawSize) * 100.0 / rawSize);
+        out.printf("  Object overhead:   %.1f%%%n", (size - rawSize) * 100.0 / size);
         out.println();
     }
 

--- a/jol-cli/src/main/java/org/openjdk/jol/operations/HeapDumpEstimates.java
+++ b/jol-cli/src/main/java/org/openjdk/jol/operations/HeapDumpEstimates.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2013, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2023, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,54 +24,91 @@
  */
 package org.openjdk.jol.operations;
 
+import org.openjdk.jol.Operation;
 import org.openjdk.jol.datamodel.*;
-import org.openjdk.jol.info.ClassLayout;
+import org.openjdk.jol.heap.HeapDumpReader;
+import org.openjdk.jol.info.ClassData;
 import org.openjdk.jol.layouters.HotSpotLayouter;
 import org.openjdk.jol.layouters.Layouter;
 import org.openjdk.jol.layouters.RawLayouter;
+import org.openjdk.jol.util.Multiset;
+
+import java.io.File;
 
 import static java.lang.System.out;
 
 /**
  * @author Aleksey Shipilev
  */
-public class ObjectEstimates extends ClasspathedOperation {
+public class HeapDumpEstimates implements Operation {
 
     @Override
     public String label() {
-        return "estimates";
+        return "heapdump-estimates";
     }
 
     @Override
     public String description() {
-        return "Simulate the class layout in different VM modes.";
+        return "Consume the heap dump and simulate the class layout in different VM modes";
     }
 
-    @Override
-    protected void runWith(Class<?> klass) {
+    public void run(String... args) throws Exception {
+        if (args.length == 0) {
+            System.err.println("Expected a hprof file name.");
+            return;
+        }
+        String path = args[0];
+
+        out.println("Heap Dump: " + path);
+
+        HeapDumpReader reader = new HeapDumpReader(new File(path));
+        Multiset<ClassData> data = reader.parse();
+
+        long rawSize = 0;
+        long rawCount = 0;
+        {
+            RawLayouter rawLayouter = new RawLayouter(new Model32());
+            for (ClassData cd : data.keys()) {
+                rawSize += rawLayouter.layout(cd).instanceSize() * data.count(cd);
+                rawCount += data.count(cd);
+            }
+
+            out.println("***** User data");
+            out.printf("  Total data size: %d bytes%n", rawSize);
+            out.printf("  Object count: %d%n", rawCount);
+            out.println();
+        }
+
         for (DataModel model : EstimatedModels.MODELS_JDK8) {
             Layouter l = new HotSpotLayouter(model, 8);
-            out.println("***** " + l);
-            out.println(ClassLayout.parseClass(klass, l).toPrintable());
+            simulateWith(l, data, rawSize);
         }
 
         for (DataModel model : EstimatedModels.MODELS_JDK8) {
             Layouter l = new HotSpotLayouter(model, 15);
-            out.println("***** " + l);
-            out.println(ClassLayout.parseClass(klass, l).toPrintable());
+            simulateWith(l, data, rawSize);
         }
 
         for (DataModel model : EstimatedModels.MODELS_JDK15) {
             Layouter l = new HotSpotLayouter(model, 15);
-            out.println("***** " + l);
-            out.println(ClassLayout.parseClass(klass, l).toPrintable());
+            simulateWith(l, data, rawSize);
         }
 
         for (DataModel model : EstimatedModels.MODELS_LILLIPUT) {
             Layouter l = new HotSpotLayouter(model, 99);
-            out.println("***** " + l);
-            out.println(ClassLayout.parseClass(klass, l).toPrintable());
+            simulateWith(l, data, rawSize);
         }
+    }
+
+    private void simulateWith(Layouter layouter, Multiset<ClassData> data, long rawSize) {
+        out.println("***** " + layouter);
+        long size = 0L;
+        for (ClassData cd : data.keys()) {
+            size += layouter.layout(cd).instanceSize() * data.count(cd);
+        }
+        out.printf("  Total object size: %d bytes%n", size);
+        out.printf("  Object overhead: %.2f%%%n", (size - rawSize) * 100.0 / rawSize);
+        out.println();
     }
 
 }

--- a/jol-core/src/main/java/org/openjdk/jol/datamodel/Model64_Lilliput.java
+++ b/jol-core/src/main/java/org/openjdk/jol/datamodel/Model64_Lilliput.java
@@ -33,24 +33,26 @@ public class Model64_Lilliput implements DataModel {
 
     private final int align;
     private final boolean compRefs;
+    private final boolean target;
 
     public Model64_Lilliput() {
-        this(false, 8);
+        this(false, 8, false);
     }
 
-    public Model64_Lilliput(boolean compRefs, int align) {
+    public Model64_Lilliput(boolean compRefs, int align, boolean target) {
         this.compRefs = compRefs;
         this.align = align;
+        this.target = target;
     }
 
     @Override
     public int markHeaderSize() {
-        return 8;
+        return target ? 1 : 8;
     }
 
     @Override
     public int classHeaderSize() {
-        return 0;
+        return target ? 3 : 0;
     }
 
     @Override
@@ -95,7 +97,8 @@ public class Model64_Lilliput implements DataModel {
 
     @Override
     public String toString() {
-        return "64-bit model, Lilliput (experimental)" +
+        return "64-bit model" +
+                ", Lilliput (" + (target ? "ultimate target" : "current experiment") + ")" +
                 (compRefs ? ", compressed references" : "") +
                 ", " + align + "-byte aligned";
     }

--- a/jol-core/src/main/java/org/openjdk/jol/datamodel/Model64_Lilliput.java
+++ b/jol-core/src/main/java/org/openjdk/jol/datamodel/Model64_Lilliput.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2023, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+package org.openjdk.jol.datamodel;
+
+/**
+ * 64 bits, Lilliput (Experimental)
+ *
+ * @author Aleksey Shipilev
+ */
+public class Model64_Lilliput implements DataModel {
+
+    private final int align;
+    private final boolean compRefs;
+
+    public Model64_Lilliput() {
+        this(false, 8);
+    }
+
+    public Model64_Lilliput(boolean compRefs, int align) {
+        this.compRefs = compRefs;
+        this.align = align;
+    }
+
+    @Override
+    public int markHeaderSize() {
+        return 8;
+    }
+
+    @Override
+    public int classHeaderSize() {
+        return 0;
+    }
+
+    @Override
+    public int arrayLengthHeaderSize() {
+        return 4;
+    }
+
+    @Override
+    public int headerSize() {
+        return markHeaderSize() + classHeaderSize();
+    }
+
+    @Override
+    public int arrayHeaderSize() {
+        return headerSize() + arrayLengthHeaderSize();
+    }
+
+    @Override
+    public int sizeOf(String klass) {
+        switch (klass) {
+            case "byte":
+            case "boolean":
+                return 1;
+            case "short":
+            case "char":
+                return 2;
+            case "int":
+            case "float":
+                return 4;
+            case "long":
+            case "double":
+                return 8;
+            default:
+                return (compRefs ? 4 : 8);
+        }
+    }
+
+    @Override
+    public int objectAlignment() {
+        return align;
+    }
+
+    @Override
+    public String toString() {
+        return "64-bit model, Lilliput (experimental)" +
+                (compRefs ? ", compressed references" : "") +
+                ", " + align + "-byte aligned";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Model64_Lilliput that = (Model64_Lilliput) o;
+        return align == that.align;
+    }
+
+    @Override
+    public int hashCode() {
+        return align;
+    }
+}

--- a/jol-core/src/main/java/org/openjdk/jol/layouters/RawLayouter.java
+++ b/jol-core/src/main/java/org/openjdk/jol/layouters/RawLayouter.java
@@ -34,7 +34,7 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 
 /**
- * Layouter which packs all the fields together, regardless of the alignment.
+ * Layouter which packs all the fields together, regardless of the alignment or headers.
  *
  * @author Aleksey Shipilev
  */
@@ -52,7 +52,7 @@ public class RawLayouter implements Layouter {
 
         if (data.isArray()) {
             // special case of arrays
-            int base = model.arrayHeaderSize();
+            int base = 0;
             int scale = model.sizeOf(data.arrayComponentType());
 
             long instanceSize = base + data.arrayLength() * scale;
@@ -60,7 +60,7 @@ public class RawLayouter implements Layouter {
             return ClassLayout.create(data, result, model, instanceSize, false);
         }
 
-        int offset = model.headerSize();
+        int offset = 0;
         for (FieldData f : data.fields()) {
             int size = model.sizeOf(f.typeClass());
             result.add(new FieldLayout(f, offset, size));
@@ -68,7 +68,7 @@ public class RawLayouter implements Layouter {
         }
 
         if (result.isEmpty()) {
-            return ClassLayout.create(data, result, model, model.headerSize(), false);
+            return ClassLayout.create(data, result, model, 0, false);
         } else {
             FieldLayout f = result.last();
             return ClassLayout.create(data, result, model, f.offset() + f.size(), false);


### PR DESCRIPTION
For Lilliput, we want an easy way to estimate the potential footprint improvements. "estimate" should be extended with Lilliput models, and "heapdump-estimate" should be added to read the data from heap dumps.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903410](https://bugs.openjdk.org/browse/CODETOOLS-7903410): JOL: Extend "estimate" to heap dumps and Lilliput


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jol pull/38/head:pull/38` \
`$ git checkout pull/38`

Update a local copy of the PR: \
`$ git checkout pull/38` \
`$ git pull https://git.openjdk.org/jol pull/38/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 38`

View PR using the GUI difftool: \
`$ git pr show -t 38`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jol/pull/38.diff">https://git.openjdk.org/jol/pull/38.diff</a>

</details>
