### PR TITLE
7903412: JOL: Lilliput model should include info on compressed classes/refs

### DIFF
--- a/jol-core/src/main/java/org/openjdk/jol/datamodel/Model64_Lilliput.java
+++ b/jol-core/src/main/java/org/openjdk/jol/datamodel/Model64_Lilliput.java
@@ -99,7 +99,8 @@ public class Model64_Lilliput implements DataModel {
     public String toString() {
         return "64-bit model" +
                 ", Lilliput (" + (target ? "ultimate target" : "current experiment") + ")" +
-                (compRefs ? ", compressed references" : "") +
+                ", " + (compRefs ? "" : "NO ") + "compressed references" +
+                ", compressed classes" +
                 ", " + align + "-byte aligned";
     }
 


### PR DESCRIPTION
A little follow-up for [CODETOOLS-7903411](https://bugs.openjdk.org/browse/CODETOOLS-7903411), Lilliput model should also reply proper compressed refs/klasses status.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903412](https://bugs.openjdk.org/browse/CODETOOLS-7903412): JOL: Lilliput model should include info on compressed classes/refs


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jol pull/40/head:pull/40` \
`$ git checkout pull/40`

Update a local copy of the PR: \
`$ git checkout pull/40` \
`$ git pull https://git.openjdk.org/jol pull/40/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 40`

View PR using the GUI difftool: \
`$ git pr show -t 40`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jol/pull/40.diff">https://git.openjdk.org/jol/pull/40.diff</a>

</details>
