### PR TITLE
CODETOOLS-7903521: JOL: heapdumpstats should print array/class names properly

### DIFF
--- a/jol-core/src/main/java/org/openjdk/jol/util/ClassUtils.java
+++ b/jol-core/src/main/java/org/openjdk/jol/util/ClassUtils.java
@@ -99,6 +99,10 @@ public class ClassUtils {
     }
 
     public static String binaryToHuman(String name) {
+        if (name == null) {
+            return "<null>";
+        }
+
         int braces = 0;
         for (int c = 0; c < name.length(); c++) {
             if (name.charAt(c) == '[') {
@@ -121,12 +125,13 @@ public class ClassUtils {
             case "F": name = "float";   break;
             case "J": name = "long";    break;
             case "D": name = "double";  break;
+            case "":  name = "<error>"; braces = 0; break;
             default: {
                 if (name.charAt(name.length() - 1) == ';') {
                     // Object arrays, cut out the leading "L" and the trailing ";"
                     name = name.substring(1, name.length() - 1);
                 }
-                name = name.replace("/", ".");
+                name = name.replace('/', '.');
                 break;
             }
         }

--- a/jol-core/src/main/java/org/openjdk/jol/util/ClassUtils.java
+++ b/jol-core/src/main/java/org/openjdk/jol/util/ClassUtils.java
@@ -97,4 +97,49 @@ public class ClassUtils {
         }
         return klass.getName();
     }
+
+    public static String binaryToHuman(String name) {
+        int braces = 0;
+        for (int c = 0; c < name.length(); c++) {
+            if (name.charAt(c) == '[') {
+                braces++;
+            } else {
+                break;
+            }
+        }
+
+        if (braces > 0) {
+            name = name.substring(braces);
+        }
+
+        switch (name) {
+            case "Z": name = "boolean"; break;
+            case "B": name = "byte";    break;
+            case "C": name = "char";    break;
+            case "S": name = "short";   break;
+            case "I": name = "int";     break;
+            case "F": name = "float";   break;
+            case "J": name = "long";    break;
+            case "D": name = "double";  break;
+            default: {
+                if (name.charAt(name.length() - 1) == ';') {
+                    // Object arrays, cut out the leading "L" and the trailing ";"
+                    name = name.substring(1, name.length() - 1);
+                }
+                name = name.replace("/", ".");
+                break;
+            }
+        }
+
+        if (braces > 0) {
+            StringBuilder sb = new StringBuilder();
+            sb.append(name);
+            for (int b = 0; b < braces; b++) {
+                sb.append("[]");
+            }
+            return sb.toString();
+        } else {
+            return name;
+        }
+    }
 }

--- a/jol-core/src/test/java/org/openjdk/jol/util/ClassUtilsTest.java
+++ b/jol-core/src/test/java/org/openjdk/jol/util/ClassUtilsTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.openjdk.jol.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ClassUtilsTest {
+
+    @Test
+    public void testSingle() {
+        Assert.assertEquals("boolean",       ClassUtils.binaryToHuman("Z"));
+        Assert.assertEquals("boolean[]",     ClassUtils.binaryToHuman("[Z"));
+        Assert.assertEquals("boolean[][]",   ClassUtils.binaryToHuman("[[Z"));
+        Assert.assertEquals("boolean[][][]", ClassUtils.binaryToHuman("[[[Z"));
+
+        Assert.assertEquals("byte",          ClassUtils.binaryToHuman("B"));
+        Assert.assertEquals("byte[]",        ClassUtils.binaryToHuman("[B"));
+        Assert.assertEquals("byte[][]",      ClassUtils.binaryToHuman("[[B"));
+        Assert.assertEquals("byte[][][]",    ClassUtils.binaryToHuman("[[[B"));
+
+        Assert.assertEquals("char",          ClassUtils.binaryToHuman("C"));
+        Assert.assertEquals("char[]",        ClassUtils.binaryToHuman("[C"));
+        Assert.assertEquals("char[][]",      ClassUtils.binaryToHuman("[[C"));
+        Assert.assertEquals("char[][][]",    ClassUtils.binaryToHuman("[[[C"));
+
+        Assert.assertEquals("short",         ClassUtils.binaryToHuman("S"));
+        Assert.assertEquals("short[]",       ClassUtils.binaryToHuman("[S"));
+        Assert.assertEquals("short[][]",     ClassUtils.binaryToHuman("[[S"));
+        Assert.assertEquals("short[][][]",   ClassUtils.binaryToHuman("[[[S"));
+
+        Assert.assertEquals("int",           ClassUtils.binaryToHuman("I"));
+        Assert.assertEquals("int[]",         ClassUtils.binaryToHuman("[I"));
+        Assert.assertEquals("int[][]",       ClassUtils.binaryToHuman("[[I"));
+        Assert.assertEquals("int[][][]",     ClassUtils.binaryToHuman("[[[I"));
+
+        Assert.assertEquals("float",         ClassUtils.binaryToHuman("F"));
+        Assert.assertEquals("float[]",       ClassUtils.binaryToHuman("[F"));
+        Assert.assertEquals("float[][]",     ClassUtils.binaryToHuman("[[F"));
+        Assert.assertEquals("float[][][]",   ClassUtils.binaryToHuman("[[[F"));
+
+        Assert.assertEquals("long",          ClassUtils.binaryToHuman("J"));
+        Assert.assertEquals("long[]",        ClassUtils.binaryToHuman("[J"));
+        Assert.assertEquals("long[][]",      ClassUtils.binaryToHuman("[[J"));
+        Assert.assertEquals("long[][][]",    ClassUtils.binaryToHuman("[[[J"));
+
+        Assert.assertEquals("double",        ClassUtils.binaryToHuman("D"));
+        Assert.assertEquals("double[]",      ClassUtils.binaryToHuman("[D"));
+        Assert.assertEquals("double[][]",    ClassUtils.binaryToHuman("[[D"));
+        Assert.assertEquals("double[][][]",  ClassUtils.binaryToHuman("[[[D"));
+
+        Assert.assertEquals("java.lang.Object",       ClassUtils.binaryToHuman("java/lang/Object"));
+        Assert.assertEquals("java.lang.Object[]",     ClassUtils.binaryToHuman("[Ljava/lang/Object;"));
+        Assert.assertEquals("java.lang.Object[][]",   ClassUtils.binaryToHuman("[[Ljava/lang/Object;"));
+        Assert.assertEquals("java.lang.Object[][][]", ClassUtils.binaryToHuman("[[[Ljava/lang/Object;"));
+
+        Assert.assertEquals("java.util.HashMap$Entry",       ClassUtils.binaryToHuman("java/util/HashMap$Entry"));
+        Assert.assertEquals("java.util.HashMap$Entry[]",     ClassUtils.binaryToHuman("[Ljava/util/HashMap$Entry;"));
+        Assert.assertEquals("java.util.HashMap$Entry[][]",   ClassUtils.binaryToHuman("[[Ljava/util/HashMap$Entry;"));
+        Assert.assertEquals("java.util.HashMap$Entry[][][]", ClassUtils.binaryToHuman("[[[Ljava/util/HashMap$Entry;"));
+    }
+
+}

--- a/jol-core/src/test/java/org/openjdk/jol/util/ClassUtilsTest.java
+++ b/jol-core/src/test/java/org/openjdk/jol/util/ClassUtilsTest.java
@@ -32,6 +32,13 @@ public class ClassUtilsTest {
 
     @Test
     public void testSingle() {
+        Assert.assertEquals("<null>",        ClassUtils.binaryToHuman(null));
+
+        Assert.assertEquals("<error>",       ClassUtils.binaryToHuman(""));
+        Assert.assertEquals("<error>",       ClassUtils.binaryToHuman("["));
+        Assert.assertEquals("<error>",       ClassUtils.binaryToHuman("[["));
+        Assert.assertEquals("<error>",       ClassUtils.binaryToHuman("[[["));
+
         Assert.assertEquals("boolean",       ClassUtils.binaryToHuman("Z"));
         Assert.assertEquals("boolean[]",     ClassUtils.binaryToHuman("[Z"));
         Assert.assertEquals("boolean[][]",   ClassUtils.binaryToHuman("[[Z"));


### PR DESCRIPTION
Current "heapdumpstats" prints "Object[]" for all array types. It should print the actual type. Also, the printouts for the class names should be in more human-readable notation, not the JVM binary names.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903521](https://bugs.openjdk.org/browse/CODETOOLS-7903521): JOL: heapdumpstats should print array/class names properly (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jol.git pull/45/head:pull/45` \
`$ git checkout pull/45`

Update a local copy of the PR: \
`$ git checkout pull/45` \
`$ git pull https://git.openjdk.org/jol.git pull/45/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 45`

View PR using the GUI difftool: \
`$ git pr show -t 45`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jol/pull/45.diff">https://git.openjdk.org/jol/pull/45.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jol/pull/45#issuecomment-1679467923)