### PR TITLE
CODETOOLS-7903522: JOL: Heap dump readers should print progress

### DIFF
--- a/jol-cli/src/main/java/org/openjdk/jol/operations/HeapDumpEstimates.java
+++ b/jol-cli/src/main/java/org/openjdk/jol/operations/HeapDumpEstimates.java
@@ -67,7 +67,7 @@ public class HeapDumpEstimates implements Operation {
         out.println("'Upgrade From' is the relative footprint change against the same mode in other JDKs.");
         out.println();
 
-        HeapDumpReader reader = new HeapDumpReader(new File(path));
+        HeapDumpReader reader = new HeapDumpReader(new File(path), out);
         Multiset<ClassData> data = reader.parse();
 
         long rawSize = 0;

--- a/jol-cli/src/main/java/org/openjdk/jol/operations/HeapDumpStats.java
+++ b/jol-cli/src/main/java/org/openjdk/jol/operations/HeapDumpStats.java
@@ -64,7 +64,7 @@ public class HeapDumpStats implements Operation {
 
         out.println("Heap Dump: " + path);
 
-        HeapDumpReader reader = new HeapDumpReader(new File(path));
+        HeapDumpReader reader = new HeapDumpReader(new File(path), out);
         Multiset<ClassData> data = reader.parse();
 
         final Multiset<String> counts = new Multiset<>();

--- a/jol-cli/src/main/java/org/openjdk/jol/operations/ObjectShapes.java
+++ b/jol-cli/src/main/java/org/openjdk/jol/operations/ObjectShapes.java
@@ -87,7 +87,7 @@ public class ObjectShapes implements Operation {
     private Multiset<String> processHeapDump(String arg) {
         Multiset<String> shapes = new Multiset<>();
         try {
-            HeapDumpReader reader = new HeapDumpReader(new File(arg));
+            HeapDumpReader reader = new HeapDumpReader(new File(arg), System.out);
             Multiset<ClassData> data = reader.parse();
             for (ClassData cd : data.keys()) {
                 String shape = parseClassData(cd);

--- a/jol-cli/src/main/java/org/openjdk/jol/operations/StringCompress.java
+++ b/jol-cli/src/main/java/org/openjdk/jol/operations/StringCompress.java
@@ -132,7 +132,7 @@ public class StringCompress implements Operation {
             final Map<Long, Boolean> isCompressible = new HashMap<>();
             final Map<Long, Integer> size = new HashMap<>();
 
-            HeapDumpReader reader = new HeapDumpReader(new File(path)) {
+            HeapDumpReader reader = new HeapDumpReader(new File(path), null) {
                 @Override
                 protected void visitClass(long id, String name, List<Integer> oopIdx, int oopSize) {
                     if (name.equals("java/lang/String")) {

--- a/jol-core/src/main/java/org/openjdk/jol/heap/HeapDumpReader.java
+++ b/jol-core/src/main/java/org/openjdk/jol/heap/HeapDumpReader.java
@@ -26,16 +26,10 @@ package org.openjdk.jol.heap;
 
 import org.openjdk.jol.info.ClassData;
 import org.openjdk.jol.info.FieldData;
+import org.openjdk.jol.util.IOUtils;
 import org.openjdk.jol.util.Multiset;
 
-import java.io.BufferedInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.EOFException;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -57,6 +51,7 @@ public class HeapDumpReader {
     private final Multiset<ClassData> classCounts;
     private final Map<Long, ClassData> classDatas;
     private final File file;
+    private final PrintStream verboseOut;
 
     private int idSize;
     private long readBytes;
@@ -65,8 +60,9 @@ public class HeapDumpReader {
     private final ByteBuffer wrapBuf;
     private String header;
 
-    public HeapDumpReader(File file) throws IOException {
+    public HeapDumpReader(File file, PrintStream verboseOut) throws IOException {
         this.file = file;
+        this.verboseOut = verboseOut;
         if (file.getName().endsWith(".gz")) {
             this.is = new BufferedInputStream(new GZIPInputStream(new FileInputStream(file)), 16 * 1024 * 1024);
         } else {
@@ -112,7 +108,18 @@ public class HeapDumpReader {
         read_U4(); // timestamp, lo
         read_U4(); // timestamp, hi
 
+        long lastPrint = 0L;
+        final long printEach = 256 * 1024 * 1024;
+
+        if (verboseOut != null) {
+            verboseOut.print("Read progress: ");
+        }
+
         while (true) {
+            if ((verboseOut != null) && (readBytes - lastPrint > printEach)) {
+                verboseOut.print(readBytes / 1000 / 1000 + "M... ");
+                lastPrint = readBytes;
+            }
 
             int tag;
             try {
@@ -158,6 +165,10 @@ public class HeapDumpReader {
             if (readBytes - lastCount != len) {
                 throw new HeapDumpException(errorMessage("Expected to read " + len + " bytes, but read " + (readBytes - lastCount) + " bytes"));
             }
+        }
+
+        if (verboseOut != null) {
+            verboseOut.println("DONE");
         }
 
         return classCounts;

--- a/jol-core/src/main/java/org/openjdk/jol/heap/HeapDumpReader.java
+++ b/jol-core/src/main/java/org/openjdk/jol/heap/HeapDumpReader.java
@@ -113,11 +113,13 @@ public class HeapDumpReader {
 
         if (verboseOut != null) {
             verboseOut.print("Read progress: ");
+            verboseOut.flush();
         }
 
         while (true) {
             if ((verboseOut != null) && (readBytes - lastPrint > printEach)) {
                 verboseOut.print(readBytes / 1000 / 1000 + "M... ");
+                verboseOut.flush();
                 lastPrint = readBytes;
             }
 


### PR DESCRIPTION
For large heap dumps, it would be convenient to see the read progress.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903522](https://bugs.openjdk.org/browse/CODETOOLS-7903522): JOL: Heap dump readers should print progress (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jol.git pull/46/head:pull/46` \
`$ git checkout pull/46`

Update a local copy of the PR: \
`$ git checkout pull/46` \
`$ git pull https://git.openjdk.org/jol.git pull/46/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 46`

View PR using the GUI difftool: \
`$ git pr show -t 46`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jol/pull/46.diff">https://git.openjdk.org/jol/pull/46.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jol/pull/46#issuecomment-1679534473)