### PR TITLE
7903523: JOL: heapdumpstats should not assume JDK 8

### DIFF
--- a/jol-cli/src/main/java/org/openjdk/jol/operations/HeapDumpStats.java
+++ b/jol-cli/src/main/java/org/openjdk/jol/operations/HeapDumpStats.java
@@ -79,6 +79,7 @@ public class HeapDumpStats implements Operation {
         final Multiset<String> sizes = new Multiset<>();
 
         Layouter layouter = new HotSpotLayouter(new ModelVM(), getVMVersion());
+        out.println();
         out.println(layouter);
         out.println();
 
@@ -93,7 +94,7 @@ public class HeapDumpStats implements Operation {
 
         final int printFirst = Integer.getInteger("printFirst", 30);
 
-        out.println("Printing first " + printFirst + " objects by size. Use -DprintFirst=# to override.");
+        out.println("Printing first " + printFirst + " object classes by size. Use -DprintFirst=# to override.");
         out.println();
 
         int idx = 0;
@@ -104,6 +105,9 @@ public class HeapDumpStats implements Operation {
             long cnt = counts.count(name);
             long size = sizes.count(name);
             out.printf(" %10d %10d %10d   %s%n", cnt, size / cnt, size, name);
+        }
+        if (sorted.size() > printFirst) {
+            out.printf(" %10s %10s %10s   %s%n", "", "", "", "...");
         }
         out.println("-------------------------------------------------------------------------");
         out.printf(" %10d %10s %10d   %s%n", counts.size(), "", sizes.size(), "(total)");

--- a/jol-cli/src/main/java/org/openjdk/jol/operations/HeapDumpStats.java
+++ b/jol-cli/src/main/java/org/openjdk/jol/operations/HeapDumpStats.java
@@ -34,8 +34,6 @@ import org.openjdk.jol.util.Multiset;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 
 import static java.lang.System.out;
@@ -55,6 +53,14 @@ public class HeapDumpStats implements Operation {
         return "Consume the heap dump and print the most frequent instances.";
     }
 
+    private int getVMVersion() {
+        try {
+            return Integer.parseInt(System.getProperty("java.specification.version"));
+        } catch (Exception e) {
+            return 8;
+        }
+    }
+
     public void run(String... args) throws Exception {
         if (args.length == 0) {
             System.err.println("Expected a hprof file name.");
@@ -67,10 +73,15 @@ public class HeapDumpStats implements Operation {
         HeapDumpReader reader = new HeapDumpReader(new File(path), out);
         Multiset<ClassData> data = reader.parse();
 
+        out.println();
+
         final Multiset<String> counts = new Multiset<>();
         final Multiset<String> sizes = new Multiset<>();
 
-        Layouter layouter = new HotSpotLayouter(new ModelVM(), 8);
+        Layouter layouter = new HotSpotLayouter(new ModelVM(), getVMVersion());
+        out.println(layouter);
+        out.println();
+
         for (ClassData cd : data.keys()) {
             long size = layouter.layout(cd).instanceSize();
             counts.add(cd.name(), data.count(cd));
@@ -81,6 +92,9 @@ public class HeapDumpStats implements Operation {
         sorted.sort((o1, o2) -> Long.compare(sizes.count(o2), sizes.count(o1)));
 
         final int printFirst = Integer.getInteger("printFirst", 30);
+
+        out.println("Printing first " + printFirst + " objects by size. Use -DprintFirst=# to override.");
+        out.println();
 
         int idx = 0;
         out.printf(" %10s %10s %10s   %s%n", "COUNT", "AVG", "SIZE", "DESCRIPTION");

--- a/jol-core/src/main/java/org/openjdk/jol/datamodel/ModelVM.java
+++ b/jol-core/src/main/java/org/openjdk/jol/datamodel/ModelVM.java
@@ -71,7 +71,7 @@ public class ModelVM implements DataModel {
     @Override
     public String toString() {
         return "Current VM: " +
-                (VM.current().objectHeaderSize() + "-byte object header, ") +
+                (headerSize() + "-byte object header, ") +
                 (sizeOf("java.lang.Object") + "-byte references, ") +
                 (objectAlignment() + "-byte aligned");
     }

--- a/jol-core/src/main/java/org/openjdk/jol/datamodel/ModelVM.java
+++ b/jol-core/src/main/java/org/openjdk/jol/datamodel/ModelVM.java
@@ -70,7 +70,10 @@ public class ModelVM implements DataModel {
 
     @Override
     public String toString() {
-        return "Current VM";
+        return "Current VM: " +
+                (VM.current().objectHeaderSize() + "-byte object header, ") +
+                (sizeOf("java.lang.Object") + "-byte references, ") +
+                (objectAlignment() + "-byte aligned");
     }
 
     @Override

--- a/jol-core/src/main/java/org/openjdk/jol/datamodel/ModelVM.java
+++ b/jol-core/src/main/java/org/openjdk/jol/datamodel/ModelVM.java
@@ -33,6 +33,11 @@ import org.openjdk.jol.vm.VM;
  */
 public class ModelVM implements DataModel {
 
+    public ModelVM() {
+        // Initialize early to capture any errors here.
+        VM.current();
+    }
+
     @Override
     public int markHeaderSize() {
         return VM.current().addressSize();


### PR DESCRIPTION
There is a problem in heapdumpstats: it uses the "current VM model" for HotspotLayouter, but sets JVM version as 8. Which means it could actually fail if run on modern JDK.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903523](https://bugs.openjdk.org/browse/CODETOOLS-7903523): JOL: heapdumpstats should not assume JDK 8 (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jol.git pull/47/head:pull/47` \
`$ git checkout pull/47`

Update a local copy of the PR: \
`$ git checkout pull/47` \
`$ git pull https://git.openjdk.org/jol.git pull/47/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 47`

View PR using the GUI difftool: \
`$ git pr show -t 47`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jol/pull/47.diff">https://git.openjdk.org/jol/pull/47.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jol/pull/47#issuecomment-1679598719)