### PR TITLE
7903525: JOL: heapdumpstats usability improvements

### DIFF
--- a/jol-cli/src/main/java/org/openjdk/jol/operations/HeapDumpEstimates.java
+++ b/jol-cli/src/main/java/org/openjdk/jol/operations/HeapDumpEstimates.java
@@ -68,7 +68,7 @@ public class HeapDumpEstimates implements Operation {
         out.println("'Upgrade From' is the relative footprint change against the same mode in other JDKs.");
         out.println();
 
-        HeapDumpReader reader = new HeapDumpReader(new File(path), out);
+        HeapDumpReader reader = new HeapDumpReader(new File(path), out, null);
         Multiset<ClassData> data = reader.parse();
 
         long rawSize = 0;

--- a/jol-cli/src/main/java/org/openjdk/jol/operations/ObjectShapes.java
+++ b/jol-cli/src/main/java/org/openjdk/jol/operations/ObjectShapes.java
@@ -87,7 +87,7 @@ public class ObjectShapes implements Operation {
     private Multiset<String> processHeapDump(String arg) {
         Multiset<String> shapes = new Multiset<>();
         try {
-            HeapDumpReader reader = new HeapDumpReader(new File(arg), System.out);
+            HeapDumpReader reader = new HeapDumpReader(new File(arg), System.out, null);
             Multiset<ClassData> data = reader.parse();
             for (ClassData cd : data.keys()) {
                 String shape = parseClassData(cd);


### PR DESCRIPTION
We need to be able to sort by column, have better descriptions, etc. Additionally, it does not have to read the large arrays for just the stats.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903525](https://bugs.openjdk.org/browse/CODETOOLS-7903525): JOL: heapdumpstats usability improvements (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jol.git pull/48/head:pull/48` \
`$ git checkout pull/48`

Update a local copy of the PR: \
`$ git checkout pull/48` \
`$ git pull https://git.openjdk.org/jol.git pull/48/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 48`

View PR using the GUI difftool: \
`$ git pr show -t 48`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jol/pull/48.diff">https://git.openjdk.org/jol/pull/48.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jol/pull/48#issuecomment-1680168225)