### PR TITLE
7903532: JOL: Hotspot layouter assumes array bases are aligned to 4 bytes

### DIFF
--- a/jol-core/pom.xml
+++ b/jol-core/pom.xml
@@ -82,98 +82,194 @@ questions.
                         </configuration>
                     </execution>
                     <execution>
-                        <id>tests-minus-coops-minus-ccp</id>
+                        <id>tests-1g-minus-coops-minus-ccp</id>
                         <phase>test</phase>
                         <goals>
                             <goal>test</goal>
                         </goals>
                         <configuration>
-                            <argLine>-XX:-UseCompressedOops -XX:-UseCompressedClassPointers -Xmx1g</argLine>
+                            <argLine>-Xmx1g -XX:-UseCompressedOops -XX:-UseCompressedClassPointers</argLine>
                             <forkCount>4</forkCount>
                             <reuseForks>true</reuseForks>
                         </configuration>
                     </execution>
                     <execution>
-                        <id>tests-plus-coops-plus-ccp</id>
+                        <id>tests-1g-plus-coops-plus-ccp</id>
                         <phase>test</phase>
                         <goals>
                             <goal>test</goal>
                         </goals>
                         <configuration>
-                            <argLine>-XX:+UseCompressedOops -XX:+UseCompressedClassPointers -Xmx1g</argLine>
+                            <argLine>-Xmx1g -XX:+UseCompressedOops -XX:+UseCompressedClassPointers</argLine>
                             <forkCount>4</forkCount>
                             <reuseForks>true</reuseForks>
                         </configuration>
                     </execution>
                     <execution>
-                        <id>tests-plus-coops-minus-ccp</id>
+                        <id>tests-1g-plus-coops-minus-ccp</id>
                         <phase>test</phase>
                         <goals>
                             <goal>test</goal>
                         </goals>
                         <configuration>
-                            <argLine>-XX:+UseCompressedOops -XX:-UseCompressedClassPointers -Xmx1g</argLine>
+                            <argLine>-Xmx1g -XX:+UseCompressedOops -XX:-UseCompressedClassPointers</argLine>
                             <forkCount>4</forkCount>
                             <reuseForks>true</reuseForks>
                         </configuration>
                     </execution>
                     <execution>
-                        <id>tests-minus-coops-plus-ccp</id>
+                        <id>tests-1g-minus-coops-plus-ccp</id>
                         <phase>test</phase>
                         <goals>
                             <goal>test</goal>
                         </goals>
                         <configuration>
-                            <argLine>-XX:-UseCompressedOops -XX:+UseCompressedClassPointers -Xmx1g</argLine>
+                            <argLine>-Xmx1g -XX:-UseCompressedOops -XX:+UseCompressedClassPointers</argLine>
                             <forkCount>4</forkCount>
                             <reuseForks>true</reuseForks>
                         </configuration>
                     </execution>
                     <execution>
-                        <id>tests-minus-coops-minus-ccp-align16</id>
+                        <id>tests-1g-minus-coops-minus-ccp-align16</id>
                         <phase>test</phase>
                         <goals>
                             <goal>test</goal>
                         </goals>
                         <configuration>
-                            <argLine>-XX:-UseCompressedOops -XX:-UseCompressedClassPointers -XX:ObjectAlignmentInBytes=16 -Xmx1g</argLine>
+                            <argLine>-Xmx1g -XX:-UseCompressedOops -XX:-UseCompressedClassPointers -XX:ObjectAlignmentInBytes=16</argLine>
                             <forkCount>4</forkCount>
                             <reuseForks>true</reuseForks>
                         </configuration>
                     </execution>
                     <execution>
-                        <id>tests-plus-coops-plus-ccp-align16</id>
+                        <id>tests-1g-plus-coops-plus-ccp-align16</id>
                         <phase>test</phase>
                         <goals>
                             <goal>test</goal>
                         </goals>
                         <configuration>
-                            <argLine>-XX:+UseCompressedOops -XX:+UseCompressedClassPointers -XX:ObjectAlignmentInBytes=16 -Xmx1g</argLine>
+                            <argLine>-Xmx1g -XX:+UseCompressedOops -XX:+UseCompressedClassPointers -XX:ObjectAlignmentInBytes=16</argLine>
                             <forkCount>4</forkCount>
                             <reuseForks>true</reuseForks>
                         </configuration>
                     </execution>
                     <execution>
-                        <id>tests-plus-coops-minus-ccp-align16</id>
+                        <id>tests-1g-plus-coops-minus-ccp-align16</id>
                         <phase>test</phase>
                         <goals>
                             <goal>test</goal>
                         </goals>
                         <configuration>
-                            <argLine>-XX:+UseCompressedOops -XX:-UseCompressedClassPointers -XX:ObjectAlignmentInBytes=16 -Xmx1g</argLine>
+                            <argLine>-Xmx1g -XX:+UseCompressedOops -XX:-UseCompressedClassPointers -XX:ObjectAlignmentInBytes=16</argLine>
                             <forkCount>4</forkCount>
                             <reuseForks>true</reuseForks>
                         </configuration>
                     </execution>
                     <execution>
-                        <id>tests-minus-coops-plus-ccp-align16</id>
+                        <id>tests-1g-minus-coops-plus-ccp-align16</id>
                         <phase>test</phase>
                         <goals>
                             <goal>test</goal>
                         </goals>
                         <configuration>
-                            <argLine>-XX:-UseCompressedOops -XX:+UseCompressedClassPointers -XX:ObjectAlignmentInBytes=16 -Xmx1g</argLine>
+                            <argLine>-Xmx1g -XX:-UseCompressedOops -XX:+UseCompressedClassPointers -XX:ObjectAlignmentInBytes=16</argLine>
                             <forkCount>4</forkCount>
+                            <reuseForks>true</reuseForks>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>tests-4g-minus-coops-minus-ccp</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <argLine>-Xmx4g -XX:-UseCompressedOops -XX:-UseCompressedClassPointers</argLine>
+                            <forkCount>1</forkCount>
+                            <reuseForks>true</reuseForks>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>tests-4g-plus-coops-plus-ccp</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <argLine>-Xmx4g -XX:+UseCompressedOops -XX:+UseCompressedClassPointers</argLine>
+                            <forkCount>1</forkCount>
+                            <reuseForks>true</reuseForks>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>tests-4g-plus-coops-minus-ccp</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <argLine>-Xmx4g -XX:+UseCompressedOops -XX:-UseCompressedClassPointers</argLine>
+                            <forkCount>1</forkCount>
+                            <reuseForks>true</reuseForks>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>tests-4g-minus-coops-plus-ccp</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <argLine>-Xmx4g -XX:-UseCompressedOops -XX:+UseCompressedClassPointers</argLine>
+                            <forkCount>1</forkCount>
+                            <reuseForks>true</reuseForks>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>tests-4g-minus-coops-minus-ccp-align16</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <argLine>-Xmx4g -XX:-UseCompressedOops -XX:-UseCompressedClassPointers -XX:ObjectAlignmentInBytes=16</argLine>
+                            <forkCount>1</forkCount>
+                            <reuseForks>true</reuseForks>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>tests-4g-plus-coops-plus-ccp-align16</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <argLine>-Xmx4g -XX:+UseCompressedOops -XX:+UseCompressedClassPointers -XX:ObjectAlignmentInBytes=16</argLine>
+                            <forkCount>1</forkCount>
+                            <reuseForks>true</reuseForks>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>tests-4g-plus-coops-minus-ccp-align16</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <argLine>-Xmx4g -XX:+UseCompressedOops -XX:-UseCompressedClassPointers -XX:ObjectAlignmentInBytes=16</argLine>
+                            <forkCount>1</forkCount>
+                            <reuseForks>true</reuseForks>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>tests-4g-minus-coops-plus-ccp-align16</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <argLine>-Xmx4g -XX:-UseCompressedOops -XX:+UseCompressedClassPointers -XX:ObjectAlignmentInBytes=16</argLine>
+                            <forkCount>1</forkCount>
                             <reuseForks>true</reuseForks>
                         </configuration>
                     </execution>

--- a/jol-core/pom.xml
+++ b/jol-core/pom.xml
@@ -72,79 +72,108 @@ questions.
                 <executions>
                     <execution>
                         <id>default-test</id>
-                        <configuration>
-                            <skip>true</skip>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>tests-minus-coops-1g</id>
                         <phase>test</phase>
                         <goals>
                             <goal>test</goal>
                         </goals>
                         <configuration>
-                            <argLine>-XX:-UseCompressedOops -Xmx1g</argLine>
                             <forkCount>4</forkCount>
                             <reuseForks>true</reuseForks>
                         </configuration>
                     </execution>
                     <execution>
-                        <id>tests-plus-coops-1g</id>
+                        <id>tests-minus-coops-minus-ccp</id>
                         <phase>test</phase>
                         <goals>
                             <goal>test</goal>
                         </goals>
                         <configuration>
-                            <argLine>-XX:+UseCompressedOops -Xmx1g</argLine>
+                            <argLine>-XX:-UseCompressedOops -XX:-UseCompressedClassPointers -Xmx1g</argLine>
                             <forkCount>4</forkCount>
                             <reuseForks>true</reuseForks>
                         </configuration>
                     </execution>
                     <execution>
-                        <id>tests-plus-coops-4g</id>
+                        <id>tests-plus-coops-plus-ccp</id>
                         <phase>test</phase>
                         <goals>
                             <goal>test</goal>
                         </goals>
                         <configuration>
-                            <argLine>-XX:+UseCompressedOops -Xmx4g</argLine>
-                            <forkCount>1</forkCount>
-                            <reuseForks>true</reuseForks>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>tests-minus-coops-1g-align16</id>
-                        <phase>test</phase>
-                        <goals>
-                            <goal>test</goal>
-                        </goals>
-                        <configuration>
-                            <argLine>-XX:-UseCompressedOops -Xmx1g -XX:ObjectAlignmentInBytes=16</argLine>
+                            <argLine>-XX:+UseCompressedOops -XX:+UseCompressedClassPointers -Xmx1g</argLine>
                             <forkCount>4</forkCount>
                             <reuseForks>true</reuseForks>
                         </configuration>
                     </execution>
                     <execution>
-                        <id>tests-plus-coops-1g-align16</id>
+                        <id>tests-plus-coops-minus-ccp</id>
                         <phase>test</phase>
                         <goals>
                             <goal>test</goal>
                         </goals>
                         <configuration>
-                            <argLine>-XX:+UseCompressedOops -Xmx1g -XX:ObjectAlignmentInBytes=16</argLine>
+                            <argLine>-XX:+UseCompressedOops -XX:-UseCompressedClassPointers -Xmx1g</argLine>
                             <forkCount>4</forkCount>
                             <reuseForks>true</reuseForks>
                         </configuration>
                     </execution>
                     <execution>
-                        <id>tests-plus-coops-4g-align16</id>
+                        <id>tests-minus-coops-plus-ccp</id>
                         <phase>test</phase>
                         <goals>
                             <goal>test</goal>
                         </goals>
                         <configuration>
-                            <argLine>-XX:+UseCompressedOops -Xmx4g -XX:ObjectAlignmentInBytes=16</argLine>
-                            <forkCount>1</forkCount>
+                            <argLine>-XX:-UseCompressedOops -XX:+UseCompressedClassPointers -Xmx1g</argLine>
+                            <forkCount>4</forkCount>
+                            <reuseForks>true</reuseForks>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>tests-minus-coops-minus-ccp-align16</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <argLine>-XX:-UseCompressedOops -XX:-UseCompressedClassPointers -XX:ObjectAlignmentInBytes=16 -Xmx1g</argLine>
+                            <forkCount>4</forkCount>
+                            <reuseForks>true</reuseForks>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>tests-plus-coops-plus-ccp-align16</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <argLine>-XX:+UseCompressedOops -XX:+UseCompressedClassPointers -XX:ObjectAlignmentInBytes=16 -Xmx1g</argLine>
+                            <forkCount>4</forkCount>
+                            <reuseForks>true</reuseForks>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>tests-plus-coops-minus-ccp-align16</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <argLine>-XX:+UseCompressedOops -XX:-UseCompressedClassPointers -XX:ObjectAlignmentInBytes=16 -Xmx1g</argLine>
+                            <forkCount>4</forkCount>
+                            <reuseForks>true</reuseForks>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>tests-minus-coops-plus-ccp-align16</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>test</goal>
+                        </goals>
+                        <configuration>
+                            <argLine>-XX:-UseCompressedOops -XX:+UseCompressedClassPointers -XX:ObjectAlignmentInBytes=16 -Xmx1g</argLine>
+                            <forkCount>4</forkCount>
                             <reuseForks>true</reuseForks>
                         </configuration>
                     </execution>

--- a/jol-core/src/main/java/org/openjdk/jol/datamodel/DataModel.java
+++ b/jol-core/src/main/java/org/openjdk/jol/datamodel/DataModel.java
@@ -79,4 +79,10 @@ public interface DataModel {
      */
     int objectAlignment();
 
+    /**
+     * Return the address size for this model: the size of the native pointer.
+     *
+     * @return address size in bytes
+     */
+    int addressSize();
 }

--- a/jol-core/src/main/java/org/openjdk/jol/datamodel/Model32.java
+++ b/jol-core/src/main/java/org/openjdk/jol/datamodel/Model32.java
@@ -94,6 +94,11 @@ public class Model32 implements DataModel {
     }
 
     @Override
+    public int addressSize() {
+        return 4;
+    }
+
+    @Override
     public String toString() {
         return "32-bit model, " + align + "-byte aligned";
     }

--- a/jol-core/src/main/java/org/openjdk/jol/datamodel/Model64.java
+++ b/jol-core/src/main/java/org/openjdk/jol/datamodel/Model64.java
@@ -98,6 +98,11 @@ public class Model64 implements DataModel {
     }
 
     @Override
+    public int addressSize() {
+        return 8;
+    }
+
+    @Override
     public String toString() {
         return "64-bit model" +
                 ", " + (compRefs ? "" : "NO ") + "compressed references" +

--- a/jol-core/src/main/java/org/openjdk/jol/datamodel/Model64_Lilliput.java
+++ b/jol-core/src/main/java/org/openjdk/jol/datamodel/Model64_Lilliput.java
@@ -96,6 +96,11 @@ public class Model64_Lilliput implements DataModel {
     }
 
     @Override
+    public int addressSize() {
+        return 8;
+    }
+
+    @Override
     public String toString() {
         return "64-bit model" +
                 ", Lilliput (" + (target ? "ultimate target" : "current experiment") + ")" +

--- a/jol-core/src/main/java/org/openjdk/jol/datamodel/ModelVM.java
+++ b/jol-core/src/main/java/org/openjdk/jol/datamodel/ModelVM.java
@@ -74,6 +74,11 @@ public class ModelVM implements DataModel {
     }
 
     @Override
+    public int addressSize() {
+        return VM.current().addressSize();
+    }
+
+    @Override
     public String toString() {
         return "Current VM: " +
                 (headerSize() + "-byte object header, ") +

--- a/jol-core/src/main/java/org/openjdk/jol/info/ClassLayout.java
+++ b/jol-core/src/main/java/org/openjdk/jol/info/ClassLayout.java
@@ -222,12 +222,7 @@ public class ClassLayout {
 
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder();
-        for (FieldLayout f : fields()) {
-            sb.append(f).append("\n");
-        }
-        sb.append("size = ").append(size).append("\n");
-        return sb.toString();
+        return toPrintable();
     }
 
     /**
@@ -471,9 +466,12 @@ public class ClassLayout {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
+
         ClassLayout that = (ClassLayout) o;
         return fields.equals(that.fields) &&
-                model.equals(that.model);
+                model.equals(that.model) &&
+                isArray == that.isArray &&
+                size == that.size;
     }
 
     @Override

--- a/jol-core/src/main/java/org/openjdk/jol/layouters/HotSpotLayouter.java
+++ b/jol-core/src/main/java/org/openjdk/jol/layouters/HotSpotLayouter.java
@@ -31,7 +31,6 @@ import org.openjdk.jol.info.FieldData;
 import org.openjdk.jol.info.FieldLayout;
 import org.openjdk.jol.util.MathUtil;
 
-import java.lang.IllegalStateException;
 import java.util.*;
 
 import static org.openjdk.jol.layouters.FieldAllocationType.*;
@@ -80,9 +79,12 @@ public class HotSpotLayouter implements Layouter {
             int base = model.arrayHeaderSize();
             int scale = model.sizeOf(cd.arrayComponentType());
 
+            // Array bases are aligned by HeapWord size:
+            //  https://bugs.openjdk.java.net/browse/JDK-8139457
+            base = MathUtil.align(base, Math.max(model.addressSize(), scale));
+
             long instanceSize = base + cd.arrayLength() * scale;
             instanceSize = MathUtil.align(instanceSize, model.objectAlignment());
-            base = MathUtil.align(base, Math.max(4, scale));
 
             SortedSet<FieldLayout> result = new TreeSet<>();
             result.add(new FieldLayout(FieldData.create(cd.arrayClass(), "<elements>", cd.arrayComponentType()), base, scale * cd.arrayLength()));


### PR DESCRIPTION
This is actually not true in current VMs, due to [JDK-8139457](https://bugs.openjdk.org/browse/JDK-8139457). This means HotspotLayouter underestimates the array sizes. This was not caught before, because we did not have good tests for arrays.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903532](https://bugs.openjdk.org/browse/CODETOOLS-7903532): JOL: Hotspot layouter assumes array bases are aligned to 4 bytes (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jol.git pull/49/head:pull/49` \
`$ git checkout pull/49`

Update a local copy of the PR: \
`$ git checkout pull/49` \
`$ git pull https://git.openjdk.org/jol.git pull/49/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 49`

View PR using the GUI difftool: \
`$ git pr show -t 49`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jol/pull/49.diff">https://git.openjdk.org/jol/pull/49.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jol/pull/49#issuecomment-1689802292)