### PR TITLE
7903535: JOL: Show array base improvements in heapdump-estimates

### DIFF
--- a/jol-cli/src/main/java/org/openjdk/jol/operations/EstimatedModels.java
+++ b/jol-cli/src/main/java/org/openjdk/jol/operations/EstimatedModels.java
@@ -42,12 +42,12 @@ public class EstimatedModels {
     };
 
     static final DataModel[] MODELS_LILLIPUT = new DataModel[]{
-            new Model64_Lilliput(false, 8, false),
-            new Model64_Lilliput(true, 8, false),
-            new Model64_Lilliput(true, 16, false),
-            new Model64_Lilliput(false, 8, true),
-            new Model64_Lilliput(true, 8, true),
-            new Model64_Lilliput(true, 16, true),
+            new Model64_Lilliput(false, 8, 8, false),
+            new Model64_Lilliput(true, 8, 8, false),
+            new Model64_Lilliput(true, 16, 8, false),
+            new Model64_Lilliput(false, 8, 8, true),
+            new Model64_Lilliput(true, 8, 8, true),
+            new Model64_Lilliput(true, 16, 8, true),
     };
 
 }

--- a/jol-cli/src/main/java/org/openjdk/jol/operations/HeapDumpEstimates.java
+++ b/jol-cli/src/main/java/org/openjdk/jol/operations/HeapDumpEstimates.java
@@ -100,17 +100,13 @@ public class HeapDumpEstimates implements Operation {
         out.println("=== Stock 32-bit OpenJDK");
         out.println();
 
-        long jdk8_32 = computeWithLayouter(data, new HotSpotLayouter(new Model32(), 8));;
+        long jdk8_32 = computeWithLayouter(data, new HotSpotLayouter(new Model32(), 8));
         {
             out.printf("%10s, %10s,     %s%n",
                     "Footprint", "Overhead", "Description"
             );
 
-            out.printf("%10s, %10s,     %s%n",
-                    MathUtil.inProperUnits(jdk8_32),
-                    MathUtil.diffPercent(jdk8_32, rawSize),
-                    "32-bit (<4 GB heap)"
-            );
+            printLine("32-bit (<4 GB heap)",              rawSize,    jdk8_32);
         }
         out.println();
 
@@ -118,10 +114,10 @@ public class HeapDumpEstimates implements Operation {
         out.println();
 
         long jdk8_noCoops =         computeWithLayouter(data, new HotSpotLayouter(new Model64(false, false), 8));
-        long jdk8_coops =           computeWithLayouter(data, new HotSpotLayouter(new Model64(true, true, 8), 8));
-        long jdk8_coops_align16 =   computeWithLayouter(data, new HotSpotLayouter(new Model64(true, true, 16), 8));
-        long jdk8_coops_align32 =   computeWithLayouter(data, new HotSpotLayouter(new Model64(true, true, 32), 8));
-        long jdk8_coops_align64 =   computeWithLayouter(data, new HotSpotLayouter(new Model64(true, true, 64), 8));
+        long jdk8_coops =           computeWithLayouter(data, new HotSpotLayouter(new Model64(true, true,   8), 8));
+        long jdk8_coops_align16 =   computeWithLayouter(data, new HotSpotLayouter(new Model64(true, true,  16), 8));
+        long jdk8_coops_align32 =   computeWithLayouter(data, new HotSpotLayouter(new Model64(true, true,  32), 8));
+        long jdk8_coops_align64 =   computeWithLayouter(data, new HotSpotLayouter(new Model64(true, true,  64), 8));
         long jdk8_coops_align128 =  computeWithLayouter(data, new HotSpotLayouter(new Model64(true, true, 128), 8));
         long jdk8_coops_align256 =  computeWithLayouter(data, new HotSpotLayouter(new Model64(true, true, 256), 8));
 
@@ -130,62 +126,21 @@ public class HeapDumpEstimates implements Operation {
                     "Footprint", "Overhead", "JVM Mode", "Description"
             );
 
-            out.printf("%10s, %10s, %10s,     %s%n",
-                    MathUtil.inProperUnits(jdk8_noCoops),
-                    MathUtil.diffPercent(jdk8_noCoops, rawSize),
-                    MathUtil.diffPercent(jdk8_noCoops, jdk8_coops),
-                    msg_noCoops
-            );
-
-            out.printf("%10s, %10s, %10s,     %s%n",
-                    MathUtil.inProperUnits(jdk8_coops),
-                    MathUtil.diffPercent(jdk8_coops, rawSize),
-                    MathUtil.diffPercent(jdk8_coops, jdk8_coops),
-                    msg_coops
-            );
-
-            out.printf("%10s, %10s, %10s,     %s%n",
-                    MathUtil.inProperUnits(jdk8_coops_align16),
-                    MathUtil.diffPercent(jdk8_coops_align16, rawSize),
-                    MathUtil.diffPercent(jdk8_coops_align16, jdk8_coops),
-                    msg_coops_align16
-            );
-
-            out.printf("%10s, %10s, %10s,     %s%n",
-                    MathUtil.inProperUnits(jdk8_coops_align32),
-                    MathUtil.diffPercent(jdk8_coops_align32, rawSize),
-                    MathUtil.diffPercent(jdk8_coops_align32, jdk8_coops),
-                    msg_coops_align32
-            );
-
-            out.printf("%10s, %10s, %10s,     %s%n",
-                    MathUtil.inProperUnits(jdk8_coops_align64),
-                    MathUtil.diffPercent(jdk8_coops_align64, rawSize),
-                    MathUtil.diffPercent(jdk8_coops_align64, jdk8_coops),
-                    msg_coops_align64
-            );
-
-            out.printf("%10s, %10s, %10s,     %s%n",
-                    MathUtil.inProperUnits(jdk8_coops_align128),
-                    MathUtil.diffPercent(jdk8_coops_align128, rawSize),
-                    MathUtil.diffPercent(jdk8_coops_align128, jdk8_coops),
-                    msg_coops_align128
-            );
-
-            out.printf("%10s, %10s, %10s,     %s%n",
-                    MathUtil.inProperUnits(jdk8_coops_align256),
-                    MathUtil.diffPercent(jdk8_coops_align256, rawSize),
-                    MathUtil.diffPercent(jdk8_coops_align256, jdk8_coops),
-                    msg_coops_align256
-            );
+            printLine(msg_noCoops,              rawSize,    jdk8_noCoops,           jdk8_coops);
+            printLine(msg_coops,                rawSize,    jdk8_coops,             jdk8_coops);
+            printLine(msg_coops_align16,        rawSize,    jdk8_coops_align16,     jdk8_coops);
+            printLine(msg_coops_align32,        rawSize,    jdk8_coops_align32,     jdk8_coops);
+            printLine(msg_coops_align64,        rawSize,    jdk8_coops_align64,     jdk8_coops);
+            printLine(msg_coops_align128,       rawSize,    jdk8_coops_align128,    jdk8_coops);
+            printLine(msg_coops_align256,       rawSize,    jdk8_coops_align256,    jdk8_coops);
         }
         out.println();
 
         long jdk15_noCoops =        computeWithLayouter(data, new HotSpotLayouter(new Model64(false, true), 15));
-        long jdk15_coops =          computeWithLayouter(data, new HotSpotLayouter(new Model64(true, true, 8), 15));
-        long jdk15_coops_align16 =  computeWithLayouter(data, new HotSpotLayouter(new Model64(true, true, 16), 15));
-        long jdk15_coops_align32 =  computeWithLayouter(data, new HotSpotLayouter(new Model64(true, true, 32), 15));
-        long jdk15_coops_align64 =  computeWithLayouter(data, new HotSpotLayouter(new Model64(true, true, 64), 15));
+        long jdk15_coops =          computeWithLayouter(data, new HotSpotLayouter(new Model64(true, true,   8), 15));
+        long jdk15_coops_align16 =  computeWithLayouter(data, new HotSpotLayouter(new Model64(true, true,  16), 15));
+        long jdk15_coops_align32 =  computeWithLayouter(data, new HotSpotLayouter(new Model64(true, true,  32), 15));
+        long jdk15_coops_align64 =  computeWithLayouter(data, new HotSpotLayouter(new Model64(true, true,  64), 15));
         long jdk15_coops_align128 = computeWithLayouter(data, new HotSpotLayouter(new Model64(true, true, 128), 15));
         long jdk15_coops_align256 = computeWithLayouter(data, new HotSpotLayouter(new Model64(true, true, 256), 15));
 
@@ -198,74 +153,26 @@ public class HeapDumpEstimates implements Operation {
                     "Footprint", "Overhead", "JVM Mode", "JDK < 15", "Description"
             );
 
-            out.printf("%10s, %10s, %10s, %10s,     %s%n",
-                    MathUtil.inProperUnits(jdk15_noCoops),
-                    MathUtil.diffPercent(jdk15_noCoops, rawSize),
-                    MathUtil.diffPercent(jdk15_noCoops, jdk15_coops),
-                    MathUtil.diffPercent(jdk15_noCoops, jdk8_noCoops),
-                    msg_noCoops_ccp
-            );
-
-            out.printf("%10s, %10s, %10s, %10s,     %s%n",
-                    MathUtil.inProperUnits(jdk15_coops),
-                    MathUtil.diffPercent(jdk15_coops, rawSize),
-                    MathUtil.diffPercent(jdk15_coops, jdk15_coops),
-                    MathUtil.diffPercent(jdk15_coops, jdk8_coops),
-                    msg_coops
-            );
-
-            out.printf("%10s, %10s, %10s, %10s,     %s%n",
-                    MathUtil.inProperUnits(jdk15_coops_align16),
-                    MathUtil.diffPercent(jdk15_coops_align16, rawSize),
-                    MathUtil.diffPercent(jdk15_coops_align16, jdk15_coops),
-                    MathUtil.diffPercent(jdk15_coops_align16, jdk8_coops_align16),
-                    msg_coops_align16
-            );
-
-            out.printf("%10s, %10s, %10s, %10s,     %s%n",
-                    MathUtil.inProperUnits(jdk15_coops_align32),
-                    MathUtil.diffPercent(jdk15_coops_align32, rawSize),
-                    MathUtil.diffPercent(jdk15_coops_align32, jdk15_coops),
-                    MathUtil.diffPercent(jdk15_coops_align32, jdk8_coops_align32),
-                    msg_coops_align32
-            );
-
-            out.printf("%10s, %10s, %10s, %10s,     %s%n",
-                    MathUtil.inProperUnits(jdk15_coops_align64),
-                    MathUtil.diffPercent(jdk15_coops_align64, rawSize),
-                    MathUtil.diffPercent(jdk15_coops_align64, jdk15_coops),
-                    MathUtil.diffPercent(jdk15_coops_align64, jdk8_coops_align64),
-                    msg_coops_align64
-            );
-
-            out.printf("%10s, %10s, %10s, %10s,     %s%n",
-                    MathUtil.inProperUnits(jdk15_coops_align128),
-                    MathUtil.diffPercent(jdk15_coops_align128, rawSize),
-                    MathUtil.diffPercent(jdk15_coops_align128, jdk15_coops),
-                    MathUtil.diffPercent(jdk15_coops_align128, jdk8_coops_align128),
-                    msg_coops_align128
-            );
-
-            out.printf("%10s, %10s, %10s, %10s,     %s%n",
-                    MathUtil.inProperUnits(jdk15_coops_align256),
-                    MathUtil.diffPercent(jdk15_coops_align256, rawSize),
-                    MathUtil.diffPercent(jdk15_coops_align256, jdk15_coops),
-                    MathUtil.diffPercent(jdk15_coops_align256, jdk8_coops_align256),
-                    msg_coops_align256
-            );
+            printLine(msg_noCoops_ccp,      rawSize,    jdk15_noCoops,          jdk15_coops,    jdk8_noCoops);
+            printLine(msg_coops,            rawSize,    jdk15_coops,            jdk15_coops,    jdk8_coops);
+            printLine(msg_coops_align16,    rawSize,    jdk15_coops_align16,    jdk15_coops,    jdk8_coops_align16);
+            printLine(msg_coops_align32,    rawSize,    jdk15_coops_align32,    jdk15_coops,    jdk8_coops_align32);
+            printLine(msg_coops_align64,    rawSize,    jdk15_coops_align64,    jdk15_coops,    jdk8_coops_align64);
+            printLine(msg_coops_align128,   rawSize,    jdk15_coops_align128,   jdk15_coops,    jdk8_coops_align128);
+            printLine(msg_coops_align256,   rawSize,    jdk15_coops_align256,   jdk15_coops,    jdk8_coops_align256);
         }
         out.println();
 
         out.println("=== Experimental 64-bit OpenJDK: Lilliput, 64-bit headers");
         out.println();
 
-        long jdkLilliput_noCoops =          computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(false, 8, false), 99));
-        long jdkLilliput_coops =            computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true, 8, false), 99));
-        long jdkLilliput_coops_align16 =    computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true, 16, false), 99));
-        long jdkLilliput_coops_align32 =    computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true, 32, false), 99));
-        long jdkLilliput_coops_align64 =    computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true, 64, false), 99));
-        long jdkLilliput_coops_align128 =   computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true, 128, false), 99));
-        long jdkLilliput_coops_align256 =   computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true, 256, false), 99));
+        long jdkLilliput_noBase_noCoops =          computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(false,  8,    8, false), 99));
+        long jdkLilliput_noBase_coops =            computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true,   8,    8, false), 99));
+        long jdkLilliput_noBase_coops_align16 =    computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true,  16,    8, false), 99));
+        long jdkLilliput_noBase_coops_align32 =    computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true,  32,    8, false), 99));
+        long jdkLilliput_noBase_coops_align64 =    computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true,  64,    8, false), 99));
+        long jdkLilliput_noBase_coops_align128 =   computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true, 128,    8, false), 99));
+        long jdkLilliput_noBase_coops_align256 =   computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true, 256,    8, false), 99));
 
         {
             out.printf("%37s %s%n", "", "Upgrade From:");
@@ -273,81 +180,27 @@ public class HeapDumpEstimates implements Operation {
                     "Footprint", "Overhead", "JVM Mode", "JDK < 15", "JDK >= 15", "Description"
             );
 
-            out.printf("%10s, %10s, %10s, %10s, %10s,     %s%n",
-                    MathUtil.inProperUnits(jdkLilliput_noCoops),
-                    MathUtil.diffPercent(jdkLilliput_noCoops, rawSize),
-                    MathUtil.diffPercent(jdkLilliput_noCoops, jdkLilliput_coops),
-                    MathUtil.diffPercent(jdkLilliput_noCoops, jdk8_noCoops),
-                    MathUtil.diffPercent(jdkLilliput_noCoops, jdk15_noCoops),
-                    msg_noCoops_ccp
-            );
+            printLine(msg_noCoops_ccp,      rawSize, jdkLilliput_noBase_noCoops,            jdkLilliput_noBase_coops, jdk8_noCoops,         jdk15_noCoops);
+            printLine(msg_coops,            rawSize, jdkLilliput_noBase_coops,              jdkLilliput_noBase_coops, jdk8_coops,           jdk15_coops);
+            printLine(msg_coops_align16,    rawSize, jdkLilliput_noBase_coops_align16,      jdkLilliput_noBase_coops, jdk8_coops_align16,   jdk15_coops_align16);
+            printLine(msg_coops_align32,    rawSize, jdkLilliput_noBase_coops_align32,      jdkLilliput_noBase_coops, jdk8_coops_align32,   jdk15_coops_align32);
+            printLine(msg_coops_align64,    rawSize, jdkLilliput_noBase_coops_align64,      jdkLilliput_noBase_coops, jdk8_coops_align64,   jdk15_coops_align64);
+            printLine(msg_coops_align128,   rawSize, jdkLilliput_noBase_coops_align128,     jdkLilliput_noBase_coops, jdk8_coops_align128,  jdk15_coops_align128);
+            printLine(msg_coops_align256,   rawSize, jdkLilliput_noBase_coops_align256,     jdkLilliput_noBase_coops, jdk8_coops_align256,  jdk15_coops_align256);
 
-            out.printf("%10s, %10s, %10s, %10s, %10s,     %s%n",
-                    MathUtil.inProperUnits(jdkLilliput_coops),
-                    MathUtil.diffPercent(jdkLilliput_coops, rawSize),
-                    MathUtil.diffPercent(jdkLilliput_coops, jdkLilliput_coops),
-                    MathUtil.diffPercent(jdkLilliput_coops, jdk8_coops),
-                    MathUtil.diffPercent(jdkLilliput_coops, jdk15_coops),
-                    msg_coops
-            );
-
-            out.printf("%10s, %10s, %10s, %10s, %10s,     %s%n",
-                    MathUtil.inProperUnits(jdkLilliput_coops_align16),
-                    MathUtil.diffPercent(jdkLilliput_coops_align16, rawSize),
-                    MathUtil.diffPercent(jdkLilliput_coops_align16, jdkLilliput_coops),
-                    MathUtil.diffPercent(jdkLilliput_coops_align16, jdk8_coops_align16),
-                    MathUtil.diffPercent(jdkLilliput_coops_align16, jdk15_coops_align16),
-                    msg_coops_align16
-            );
-
-            out.printf("%10s, %10s, %10s, %10s, %10s,     %s%n",
-                    MathUtil.inProperUnits(jdkLilliput_coops_align32),
-                    MathUtil.diffPercent(jdkLilliput_coops_align32, rawSize),
-                    MathUtil.diffPercent(jdkLilliput_coops_align32, jdkLilliput_coops),
-                    MathUtil.diffPercent(jdkLilliput_coops_align32, jdk8_coops_align32),
-                    MathUtil.diffPercent(jdkLilliput_coops_align32, jdk15_coops_align32),
-                    msg_coops_align32
-            );
-
-            out.printf("%10s, %10s, %10s, %10s, %10s,     %s%n",
-                    MathUtil.inProperUnits(jdkLilliput_coops_align64),
-                    MathUtil.diffPercent(jdkLilliput_coops_align64, rawSize),
-                    MathUtil.diffPercent(jdkLilliput_coops_align64, jdkLilliput_coops),
-                    MathUtil.diffPercent(jdkLilliput_coops_align64, jdk8_coops_align64),
-                    MathUtil.diffPercent(jdkLilliput_coops_align64, jdk15_coops_align64),
-                    msg_coops_align64
-            );
-
-            out.printf("%10s, %10s, %10s, %10s, %10s,     %s%n",
-                    MathUtil.inProperUnits(jdkLilliput_coops_align128),
-                    MathUtil.diffPercent(jdkLilliput_coops_align128, rawSize),
-                    MathUtil.diffPercent(jdkLilliput_coops_align128, jdkLilliput_coops),
-                    MathUtil.diffPercent(jdkLilliput_coops_align128, jdk8_coops_align128),
-                    MathUtil.diffPercent(jdkLilliput_coops_align128, jdk15_coops_align128),
-                    msg_coops_align128
-            );
-
-            out.printf("%10s, %10s, %10s, %10s, %10s,     %s%n",
-                    MathUtil.inProperUnits(jdkLilliput_coops_align256),
-                    MathUtil.diffPercent(jdkLilliput_coops_align256, rawSize),
-                    MathUtil.diffPercent(jdkLilliput_coops_align256, jdkLilliput_coops),
-                    MathUtil.diffPercent(jdkLilliput_coops_align256, jdk8_coops_align256),
-                    MathUtil.diffPercent(jdkLilliput_coops_align256, jdk15_coops_align256),
-                    msg_coops_align256
-            );
         }
         out.println();
 
-        out.println("=== Experimental 64-bit OpenJDK: Lilliput, 32-bit headers");
+        out.println("=== Experimental 64-bit OpenJDK: Lilliput, 64-bit headers, array base improvements");
         out.println();
 
-        long jdkLilliput32_noCoops =        computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(false, 8, true), 99));
-        long jdkLilliput32_coops =          computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true, 8, true), 99));
-        long jdkLilliput32_coops_align16 =  computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true, 16, true), 99));
-        long jdkLilliput32_coops_align32 =  computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true, 32, true), 99));
-        long jdkLilliput32_coops_align64 =  computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true, 64, true), 99));
-        long jdkLilliput32_coops_align128 = computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true, 128, true), 99));
-        long jdkLilliput32_coops_align256 = computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true, 256, true), 99));
+        long jdkLilliput_base_noCoops =          computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(false,  8,  4, false), 99));
+        long jdkLilliput_base_coops =            computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true,   8,  4, false), 99));
+        long jdkLilliput_base_coops_align16 =    computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true,  16,  4, false), 99));
+        long jdkLilliput_base_coops_align32 =    computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true,  32,  4, false), 99));
+        long jdkLilliput_base_coops_align64 =    computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true,  64,  4, false), 99));
+        long jdkLilliput_base_coops_align128 =   computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true, 128,  4, false), 99));
+        long jdkLilliput_base_coops_align256 =   computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true, 256,  4, false), 99));
 
         {
             out.printf("%37s %s%n", "", "Upgrade From:");
@@ -355,78 +208,50 @@ public class HeapDumpEstimates implements Operation {
                     "Footprint", "Overhead", "JVM Mode", "JDK < 15", "JDK >= 15", "Lill-64", "Description"
             );
 
-            out.printf("%10s, %10s, %10s, %10s, %10s, %10s,     %s%n",
-                    MathUtil.inProperUnits(jdkLilliput32_noCoops),
-                    MathUtil.diffPercent(jdkLilliput32_noCoops, rawSize),
-                    MathUtil.diffPercent(jdkLilliput32_noCoops, jdkLilliput32_coops),
-                    MathUtil.diffPercent(jdkLilliput32_noCoops, jdk8_noCoops),
-                    MathUtil.diffPercent(jdkLilliput32_noCoops, jdk15_noCoops),
-                    MathUtil.diffPercent(jdkLilliput32_noCoops, jdkLilliput_noCoops),
-                    msg_noCoops_ccp
-            );
-
-            out.printf("%10s, %10s, %10s, %10s, %10s, %10s,     %s%n",
-                    MathUtil.inProperUnits(jdkLilliput32_coops),
-                    MathUtil.diffPercent(jdkLilliput32_coops, rawSize),
-                    MathUtil.diffPercent(jdkLilliput32_coops, jdkLilliput32_coops),
-                    MathUtil.diffPercent(jdkLilliput32_coops, jdk8_coops),
-                    MathUtil.diffPercent(jdkLilliput32_coops, jdk15_coops),
-                    MathUtil.diffPercent(jdkLilliput32_coops, jdkLilliput_coops),
-                    msg_coops
-            );
-
-            out.printf("%10s, %10s, %10s, %10s, %10s, %10s,     %s%n",
-                    MathUtil.inProperUnits(jdkLilliput32_coops_align16),
-                    MathUtil.diffPercent(jdkLilliput32_coops_align16, rawSize),
-                    MathUtil.diffPercent(jdkLilliput32_coops_align16, jdkLilliput32_coops),
-                    MathUtil.diffPercent(jdkLilliput32_coops_align16, jdk8_coops_align16),
-                    MathUtil.diffPercent(jdkLilliput32_coops_align16, jdk15_coops_align16),
-                    MathUtil.diffPercent(jdkLilliput32_coops_align16, jdkLilliput_coops_align16),
-                    msg_coops_align16
-            );
-
-            out.printf("%10s, %10s, %10s, %10s, %10s, %10s,     %s%n",
-                    MathUtil.inProperUnits(jdkLilliput32_coops_align32),
-                    MathUtil.diffPercent(jdkLilliput32_coops_align32, rawSize),
-                    MathUtil.diffPercent(jdkLilliput32_coops_align32, jdkLilliput32_coops),
-                    MathUtil.diffPercent(jdkLilliput32_coops_align32, jdk8_coops_align32),
-                    MathUtil.diffPercent(jdkLilliput32_coops_align32, jdk15_coops_align32),
-                    MathUtil.diffPercent(jdkLilliput32_coops_align32, jdkLilliput_coops_align32),
-                    msg_coops_align32
-            );
-
-            out.printf("%10s, %10s, %10s, %10s, %10s, %10s,     %s%n",
-                    MathUtil.inProperUnits(jdkLilliput32_coops_align64),
-                    MathUtil.diffPercent(jdkLilliput32_coops_align64, rawSize),
-                    MathUtil.diffPercent(jdkLilliput32_coops_align64, jdkLilliput32_coops),
-                    MathUtil.diffPercent(jdkLilliput32_coops_align64, jdk8_coops_align64),
-                    MathUtil.diffPercent(jdkLilliput32_coops_align64, jdk15_coops_align64),
-                    MathUtil.diffPercent(jdkLilliput32_coops_align64, jdkLilliput_coops_align64),
-                    msg_coops_align64
-            );
-
-            out.printf("%10s, %10s, %10s, %10s, %10s, %10s,     %s%n",
-                    MathUtil.inProperUnits(jdkLilliput32_coops_align128),
-                    MathUtil.diffPercent(jdkLilliput32_coops_align128, rawSize),
-                    MathUtil.diffPercent(jdkLilliput32_coops_align128, jdkLilliput32_coops),
-                    MathUtil.diffPercent(jdkLilliput32_coops_align128, jdk8_coops_align128),
-                    MathUtil.diffPercent(jdkLilliput32_coops_align128, jdk15_coops_align128),
-                    MathUtil.diffPercent(jdkLilliput32_coops_align128, jdkLilliput_coops_align128),
-                    msg_coops_align128
-            );
-
-            out.printf("%10s, %10s, %10s, %10s, %10s, %10s,     %s%n",
-                    MathUtil.inProperUnits(jdkLilliput32_coops_align256),
-                    MathUtil.diffPercent(jdkLilliput32_coops_align256, rawSize),
-                    MathUtil.diffPercent(jdkLilliput32_coops_align256, jdkLilliput32_coops),
-                    MathUtil.diffPercent(jdkLilliput32_coops_align256, jdk8_coops_align256),
-                    MathUtil.diffPercent(jdkLilliput32_coops_align256, jdk15_coops_align256),
-                    MathUtil.diffPercent(jdkLilliput32_coops_align256, jdkLilliput_coops_align256),
-                    msg_coops_align256
-            );
+            printLine(msg_noCoops_ccp,      rawSize, jdkLilliput_base_noCoops,          jdkLilliput_base_coops, jdk8_noCoops,           jdk15_noCoops,          jdkLilliput_noBase_noCoops);
+            printLine(msg_coops,            rawSize, jdkLilliput_base_coops,            jdkLilliput_base_coops, jdk8_coops,             jdk15_coops,            jdkLilliput_noBase_coops);
+            printLine(msg_coops_align16,    rawSize, jdkLilliput_base_coops_align16,    jdkLilliput_base_coops, jdk8_coops_align16,     jdk15_coops_align16,    jdkLilliput_noBase_coops_align16);
+            printLine(msg_coops_align32,    rawSize, jdkLilliput_base_coops_align32,    jdkLilliput_base_coops, jdk8_coops_align32,     jdk15_coops_align32,    jdkLilliput_noBase_coops_align32);
+            printLine(msg_coops_align64,    rawSize, jdkLilliput_base_coops_align64,    jdkLilliput_base_coops, jdk8_coops_align64,     jdk15_coops_align64,    jdkLilliput_noBase_coops_align64);
+            printLine(msg_coops_align128,   rawSize, jdkLilliput_base_coops_align128,   jdkLilliput_base_coops, jdk8_coops_align128,    jdk15_coops_align128,   jdkLilliput_noBase_coops_align128);
+            printLine(msg_coops_align256,   rawSize, jdkLilliput_base_coops_align256,   jdkLilliput_base_coops, jdk8_coops_align256,    jdk15_coops_align256,   jdkLilliput_noBase_coops_align256);
         }
         out.println();
 
+        out.println("=== Experimental 64-bit OpenJDK: Lilliput, 32-bit headers");
+        out.println();
+
+        long jdkLilliput32_noCoops =        computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(false,  8, 8, true), 99));
+        long jdkLilliput32_coops =          computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true,   8, 8, true), 99));
+        long jdkLilliput32_coops_align16 =  computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true,  16, 8, true), 99));
+        long jdkLilliput32_coops_align32 =  computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true,  32, 8, true), 99));
+        long jdkLilliput32_coops_align64 =  computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true,  64, 8, true), 99));
+        long jdkLilliput32_coops_align128 = computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true, 128, 8, true), 99));
+        long jdkLilliput32_coops_align256 = computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true, 256, 8, true), 99));
+
+        {
+            out.printf("%37s %s%n", "", "Upgrade From:");
+            out.printf("%10s, %10s, %10s, %10s, %10s, %10s, %10s,     %s%n",
+                    "Footprint", "Overhead", "JVM Mode", "JDK < 15", "JDK >= 15", "Lill-64", "Lill-64-AB", "Description"
+            );
+
+            printLine(msg_noCoops_ccp,    rawSize,  jdkLilliput32_noCoops,        jdkLilliput32_coops, jdk8_noCoops,          jdk15_noCoops,          jdkLilliput_noBase_noCoops,         jdkLilliput_base_noCoops);
+            printLine(msg_coops,          rawSize,  jdkLilliput32_coops,          jdkLilliput32_coops, jdk8_coops,            jdk15_coops,            jdkLilliput_noBase_coops,           jdkLilliput_base_coops);
+            printLine(msg_coops_align16,  rawSize,  jdkLilliput32_coops_align16,  jdkLilliput32_coops, jdk8_coops_align16,    jdk15_coops_align16,    jdkLilliput_noBase_coops_align16,   jdkLilliput_base_coops_align16);
+            printLine(msg_coops_align32,  rawSize,  jdkLilliput32_coops_align32,  jdkLilliput32_coops, jdk8_coops_align32,    jdk15_coops_align32,    jdkLilliput_noBase_coops_align32,   jdkLilliput_base_coops_align32);
+            printLine(msg_coops_align64,  rawSize,  jdkLilliput32_coops_align64,  jdkLilliput32_coops, jdk8_coops_align64,    jdk15_coops_align64,    jdkLilliput_noBase_coops_align64,   jdkLilliput_base_coops_align64);
+            printLine(msg_coops_align128, rawSize,  jdkLilliput32_coops_align128, jdkLilliput32_coops, jdk8_coops_align256,   jdk15_coops_align128,   jdkLilliput_noBase_coops_align128,  jdkLilliput_base_coops_align128);
+            printLine(msg_coops_align256, rawSize,  jdkLilliput32_coops_align256, jdkLilliput32_coops, jdk8_coops_align256,   jdk15_coops_align256,   jdkLilliput_noBase_coops_align256,  jdkLilliput_base_coops_align256);
+        }
+        out.println();
+    }
+
+    private static void printLine(String msg, long rawSize, long value, long... bases) {
+        out.printf("%10s, %10s, ", MathUtil.inProperUnits(value), MathUtil.diffPercent(value, rawSize));
+        for (long base : bases) {
+            out.printf("%10s, ", MathUtil.diffPercent(value, base));
+        }
+        out.printf("    %s%n", msg);
     }
 
     private static long computeWithLayouter(Multiset<ClassData> data, Layouter layouter) {
@@ -436,6 +261,5 @@ public class HeapDumpEstimates implements Operation {
         }
         return size;
     }
-
 
 }

--- a/jol-core/src/main/java/org/openjdk/jol/datamodel/DataModel.java
+++ b/jol-core/src/main/java/org/openjdk/jol/datamodel/DataModel.java
@@ -80,9 +80,9 @@ public interface DataModel {
     int objectAlignment();
 
     /**
-     * Return the address size for this model: the size of the native pointer.
+     * Return the minimal alignment for array bases.
      *
-     * @return address size in bytes
+     * @return minimal array base alignment
      */
-    int addressSize();
+    int arrayBaseAlignment();
 }

--- a/jol-core/src/main/java/org/openjdk/jol/datamodel/Model32.java
+++ b/jol-core/src/main/java/org/openjdk/jol/datamodel/Model32.java
@@ -94,7 +94,8 @@ public class Model32 implements DataModel {
     }
 
     @Override
-    public int addressSize() {
+    public int arrayBaseAlignment() {
+        // Can be just address size
         return 4;
     }
 

--- a/jol-core/src/main/java/org/openjdk/jol/datamodel/Model64.java
+++ b/jol-core/src/main/java/org/openjdk/jol/datamodel/Model64.java
@@ -98,7 +98,7 @@ public class Model64 implements DataModel {
     }
 
     @Override
-    public int addressSize() {
+    public int arrayBaseAlignment() {
         return 8;
     }
 

--- a/jol-core/src/main/java/org/openjdk/jol/datamodel/Model64_Lilliput.java
+++ b/jol-core/src/main/java/org/openjdk/jol/datamodel/Model64_Lilliput.java
@@ -32,16 +32,18 @@ package org.openjdk.jol.datamodel;
 public class Model64_Lilliput implements DataModel {
 
     private final int align;
+    private final int arrayBaseAlign;
     private final boolean compRefs;
     private final boolean target;
 
     public Model64_Lilliput() {
-        this(false, 8, false);
+        this(false, 8, 8, false);
     }
 
-    public Model64_Lilliput(boolean compRefs, int align, boolean target) {
+    public Model64_Lilliput(boolean compRefs, int align, int arrayBaseAlign, boolean target) {
         this.compRefs = compRefs;
         this.align = align;
+        this.arrayBaseAlign = target ? 4 : arrayBaseAlign;
         this.target = target;
     }
 
@@ -96,8 +98,8 @@ public class Model64_Lilliput implements DataModel {
     }
 
     @Override
-    public int addressSize() {
-        return 8;
+    public int arrayBaseAlignment() {
+        return arrayBaseAlign;
     }
 
     @Override

--- a/jol-core/src/main/java/org/openjdk/jol/datamodel/ModelVM.java
+++ b/jol-core/src/main/java/org/openjdk/jol/datamodel/ModelVM.java
@@ -73,17 +73,43 @@ public class ModelVM implements DataModel {
         return VM.current().objectAlignment();
     }
 
+    int arrayBaseAlignment;
+
+    private static int guessArrayBaseAlignment(String type) {
+        int byteOff = VM.current().arrayBaseOffset(type);
+        if ((byteOff % 8) == 0) return 8;
+        if ((byteOff % 4) == 0) return 4;
+        if ((byteOff % 2) == 0) return 2;
+        return 1;
+    }
+
     @Override
-    public int addressSize() {
-        return VM.current().addressSize();
+    public int arrayBaseAlignment() {
+        if (arrayBaseAlignment != 0) {
+            return arrayBaseAlignment;
+        }
+        int al = Integer.MAX_VALUE;
+        al = Math.min(al, guessArrayBaseAlignment("boolean"));
+        al = Math.min(al, guessArrayBaseAlignment("byte"));
+        al = Math.min(al, guessArrayBaseAlignment("short"));
+        al = Math.min(al, guessArrayBaseAlignment("char"));
+        al = Math.min(al, guessArrayBaseAlignment("int"));
+        al = Math.min(al, guessArrayBaseAlignment("float"));
+        al = Math.min(al, guessArrayBaseAlignment("long"));
+        al = Math.min(al, guessArrayBaseAlignment("double"));
+        al = Math.min(al, guessArrayBaseAlignment("Object"));
+        arrayBaseAlignment = al;
+
+        return al;
     }
 
     @Override
     public String toString() {
         return "Current VM: " +
-                (headerSize() + "-byte object header, ") +
+                (headerSize() + "-byte object headers, ") +
                 (sizeOf("java.lang.Object") + "-byte references, ") +
-                (objectAlignment() + "-byte aligned");
+                (objectAlignment() + "-byte aligned objects, ") +
+                (arrayBaseAlignment() + "-byte aligned array bases");
     }
 
     @Override

--- a/jol-core/src/main/java/org/openjdk/jol/layouters/HotSpotLayouter.java
+++ b/jol-core/src/main/java/org/openjdk/jol/layouters/HotSpotLayouter.java
@@ -81,7 +81,7 @@ public class HotSpotLayouter implements Layouter {
 
             // Array bases are aligned by HeapWord size:
             //  https://bugs.openjdk.java.net/browse/JDK-8139457
-            base = MathUtil.align(base, Math.max(model.addressSize(), scale));
+            base = MathUtil.align(base, Math.max(model.arrayBaseAlignment(), scale));
 
             long instanceSize = base + cd.arrayLength() * scale;
             instanceSize = MathUtil.align(instanceSize, model.objectAlignment());


### PR DESCRIPTION
This would help to ballpark the improvements from [JDK-8139457](https://bugs.openjdk.org/browse/JDK-8139457).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903535](https://bugs.openjdk.org/browse/CODETOOLS-7903535): JOL: Show array base improvements in heapdump-estimates (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jol.git pull/50/head:pull/50` \
`$ git checkout pull/50`

Update a local copy of the PR: \
`$ git checkout pull/50` \
`$ git pull https://git.openjdk.org/jol.git pull/50/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 50`

View PR using the GUI difftool: \
`$ git pr show -t 50`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jol/pull/50.diff">https://git.openjdk.org/jol/pull/50.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jol/pull/50#issuecomment-1690341970)