### PR TITLE
CODETOOLS-7903569: JOL: Use human-readable class names consistently

### DIFF
--- a/jol-core/src/main/java/org/openjdk/jol/info/ClassData.java
+++ b/jol-core/src/main/java/org/openjdk/jol/info/ClassData.java
@@ -101,10 +101,10 @@ public class ClassData {
     private static ClassData parse(Object o, Class klass) {
         // If this is an array, do the array parsing, instead of ordinary class.
         if (klass.isArray()) {
-            return new ClassData(o, klass.getName(), klass.getComponentType().getName(), arrayLength(o));
+            return new ClassData(o, ClassUtils.humanReadableName(klass), ClassUtils.humanReadableName(klass.getComponentType()), arrayLength(o));
         }
 
-        ClassData cd = new ClassData(o, klass.getName());
+        ClassData cd = new ClassData(o, ClassUtils.humanReadableName(klass));
         Class superKlass = klass.getSuperclass();
 
         // TODO: Move to an appropriate constructor
@@ -120,7 +120,7 @@ public class ClassData {
                     cd.addField(FieldData.parse(f));
                 }
             }
-            cd.addSuperClass(ClassUtils.getSafeName(klass));
+            cd.addSuperClass(ClassUtils.humanReadableName(klass));
         } while ((klass = klass.getSuperclass()) != null);
 
         return cd;

--- a/jol-core/src/main/java/org/openjdk/jol/info/ClassData.java
+++ b/jol-core/src/main/java/org/openjdk/jol/info/ClassData.java
@@ -101,10 +101,10 @@ public class ClassData {
     private static ClassData parse(Object o, Class klass) {
         // If this is an array, do the array parsing, instead of ordinary class.
         if (klass.isArray()) {
-            return new ClassData(o, ClassUtils.humanReadableName(klass), ClassUtils.humanReadableName(klass.getComponentType()), arrayLength(o));
+            return new ClassData(o, ClassUtils.jvmName(klass), ClassUtils.jvmName(klass.getComponentType()), arrayLength(o));
         }
 
-        ClassData cd = new ClassData(o, ClassUtils.humanReadableName(klass));
+        ClassData cd = new ClassData(o, ClassUtils.jvmName(klass));
         Class superKlass = klass.getSuperclass();
 
         // TODO: Move to an appropriate constructor

--- a/jol-core/src/main/java/org/openjdk/jol/info/FieldData.java
+++ b/jol-core/src/main/java/org/openjdk/jol/info/FieldData.java
@@ -25,9 +25,7 @@
 package org.openjdk.jol.info;
 
 import org.openjdk.jol.util.ClassUtils;
-import org.openjdk.jol.util.ObjectUtils;
 import org.openjdk.jol.vm.ContendedSupport;
-import org.openjdk.jol.vm.VM;
 
 import java.lang.reflect.Field;
 
@@ -73,9 +71,9 @@ public class FieldData {
     public static FieldData parse(Field field) {
         return new FieldData(
                 field,
-                ClassUtils.getSafeName(field.getDeclaringClass()),
+                ClassUtils.humanReadableName(field.getDeclaringClass()),
                 field.getName(),
-                ClassUtils.getSafeName(field.getType()),
+                ClassUtils.humanReadableName(field.getType()),
                 ContendedSupport.isContended(field),
                 ContendedSupport.contendedGroup(field)
         );

--- a/jol-core/src/main/java/org/openjdk/jol/info/GraphLayout.java
+++ b/jol-core/src/main/java/org/openjdk/jol/info/GraphLayout.java
@@ -24,6 +24,7 @@
  */
 package org.openjdk.jol.info;
 
+import org.openjdk.jol.util.ClassUtils;
 import org.openjdk.jol.util.Multiset;
 import org.openjdk.jol.util.ObjectUtils;
 import org.openjdk.jol.vm.VM;
@@ -82,7 +83,7 @@ public class GraphLayout {
             } else {
                 sb.append(", ");
             }
-            sb.append(String.format("%s@%xd", root.getClass().getName(), System.identityHashCode(root)));
+            sb.append(String.format("%s@%xd", ClassUtils.humanReadableName(root.getClass()), System.identityHashCode(root)));
         }
         this.description = sb.toString();
     }
@@ -338,7 +339,7 @@ public class GraphLayout {
         for (Class<?> key : getClasses()) {
             long count = getClassCounts().count(key);
             long size = getClassSizes().count(key);
-            pw.printf(" %9d %9d %9d   %s%n", count, size / count, size, key.getName());
+            pw.printf(" %9d %9d %9d   %s%n", count, size / count, size, ClassUtils.humanReadableName(key));
         }
         pw.printf(" %9d %9s %9d   %s%n", totalCount(), "", totalSize(), "(total)");
         pw.println();
@@ -360,7 +361,7 @@ public class GraphLayout {
         int typeLen = "TYPE".length();
         for (long addr : addresses()) {
             GraphPathRecord r = record(addr);
-            typeLen = Math.max(typeLen, r.klass().getName().length());
+            typeLen = Math.max(typeLen, ClassUtils.humanReadableName(r.klass()).length());
         }
 
         pw.println(description + " object externals:");
@@ -376,7 +377,7 @@ public class GraphLayout {
                 pw.printf(" %16x %10d %-" + typeLen + "s %-30s %s%n", last, addr - last, "**** OVERLAP ****", "**** OVERLAP ****", "**** OVERLAP ****");
             }
 
-            pw.printf(" %16x %10d %-" + typeLen + "s %-30s %s%n", addr, size, record.klass().getName(), record.path(), ObjectUtils.safeToString(record.obj()));
+            pw.printf(" %16x %10d %-" + typeLen + "s %-30s %s%n", addr, size, ClassUtils.humanReadableName(record.klass()), record.path(), ObjectUtils.safeToString(record.obj()));
             last = addr + size;
         }
         pw.println();

--- a/jol-core/src/main/java/org/openjdk/jol/util/ClassUtils.java
+++ b/jol-core/src/main/java/org/openjdk/jol/util/ClassUtils.java
@@ -82,11 +82,14 @@ public class ClassUtils {
         return Class.forName(name, true, ClassLoader.getSystemClassLoader());
     }
 
+    public static String jvmName(Class<?> klass) {
+        return klass.getName();
+    }
+
     public static String humanReadableName(Class<?> klass) {
         // We want a human-readable class name. getName() returns JVM signature.
-        // getCanonicalName() returns proper string, unless it is hits the bug.
-        // If it fails, then we will fall back to getName()
-        //   https://bugs.openjdk.java.net/browse/JDK-8057919
+        // getCanonicalName() returns proper string, unless the class does not have any.
+        // If it fails, then we will fall back to getName() and translation to human form.
         try {
             String n = klass.getCanonicalName();
             if (n != null) {

--- a/jol-core/src/main/java/org/openjdk/jol/util/ClassUtils.java
+++ b/jol-core/src/main/java/org/openjdk/jol/util/ClassUtils.java
@@ -82,7 +82,7 @@ public class ClassUtils {
         return Class.forName(name, true, ClassLoader.getSystemClassLoader());
     }
 
-    public static String getSafeName(Class klass) {
+    public static String humanReadableName(Class<?> klass) {
         // We want a human-readable class name. getName() returns JVM signature.
         // getCanonicalName() returns proper string, unless it is hits the bug.
         // If it fails, then we will fall back to getName()
@@ -95,7 +95,7 @@ public class ClassUtils {
         } catch (Throwable e) {
             // fall-through
         }
-        return klass.getName();
+        return binaryToHuman(klass.getName());
     }
 
     public static String binaryToHuman(String name) {

--- a/jol-core/src/test/java/org/openjdk/jol/info/ClassLayoutNamesTest.java
+++ b/jol-core/src/test/java/org/openjdk/jol/info/ClassLayoutNamesTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.openjdk.jol.info;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class ClassLayoutNamesTest {
+
+    static class A {
+        int[] array = new int[10];
+        B[] bs = new B[10];
+
+        class B {
+
+        }
+    }
+
+    @Test
+    public void testPrintA() {
+        String print = ClassLayout.parseInstance(new A()).toPrintable();
+        Assert.assertTrue(print, print.contains("int[]"));
+        Assert.assertTrue(print, print.contains(".A.B[]"));
+        Assert.assertTrue(print, print.contains(".A.B"));
+    }
+
+    @Test
+    public void testPrintB() {
+        String print = ClassLayout.parseInstance(new A().new B()).toPrintable();
+        Assert.assertTrue(print, print.contains(".A"));
+    }
+
+}

--- a/jol-core/src/test/java/org/openjdk/jol/info/GraphLayoutNamesTest.java
+++ b/jol-core/src/test/java/org/openjdk/jol/info/GraphLayoutNamesTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.  Oracle designates this
+ * particular file as subject to the "Classpath" exception as provided
+ * by Oracle in the LICENSE file that accompanied this code.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package org.openjdk.jol.info;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class GraphLayoutNamesTest {
+
+    static class A {
+        int[] array = new int[10];
+        B[] bs = new B[10];
+
+        class B {
+
+        }
+    }
+
+    @Test
+    public void testPrintable() {
+        String print = GraphLayout.parseInstance(new A()).toPrintable();
+        Assert.assertTrue(print, print.contains("int[]"));
+        Assert.assertTrue(print, print.contains(".A.B[]"));
+    }
+
+    @Test
+    public void testFootprint() {
+        String print = GraphLayout.parseInstance(new A().new B()).toFootprint();
+        Assert.assertTrue(print, print.contains(".A.B[]"));
+        Assert.assertTrue(print, print.contains(".A.B"));
+    }
+
+}


### PR DESCRIPTION
There are a couple of places, where we print out JVM names for classes. Notably, it happens during "footprint". We need to consistently use the human-readable class names everywhere.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903569](https://bugs.openjdk.org/browse/CODETOOLS-7903569): JOL: Use human-readable class names consistently (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jol.git pull/51/head:pull/51` \
`$ git checkout pull/51`

Update a local copy of the PR: \
`$ git checkout pull/51` \
`$ git pull https://git.openjdk.org/jol.git pull/51/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 51`

View PR using the GUI difftool: \
`$ git pr show -t 51`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jol/pull/51.diff">https://git.openjdk.org/jol/pull/51.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jol/pull/51#issuecomment-1748662626)