### PR TITLE
7903579: JOL: Heap dump parser handles superclasses incorrectly

### DIFF
--- a/jol-core/src/main/java/org/openjdk/jol/heap/HeapDumpReader.java
+++ b/jol-core/src/main/java/org/openjdk/jol/heap/HeapDumpReader.java
@@ -196,15 +196,24 @@ public class HeapDumpReader {
             classDatas.put(klassId, cd);
         }
 
+        // Fix up superclasses for HotspotLayouter to work well.
+        for (Long klassId : classDatas.keySet()) {
+            Long key = classSupers.get(klassId);
+            if (key != null) {
+                ClassData superCd = classDatas.get(key);
+                ClassData thisCd = classDatas.get(klassId);
+                thisCd.addSuperClassData(superCd);
+            }
+        }
+
         // Compute final class counts.
         Multiset<ClassData> finalClassCounts = new Multiset<>();
         for (ClassData cd : arrayCounts.keys()) {
             finalClassCounts.add(cd, arrayCounts.count(cd));
         }
-        for (Long klassId : classDatas.keySet()) {
-            ClassData cd = classDatas.get(klassId);
-            long count = classCounts.count(klassId);
-            finalClassCounts.add(cd, count);
+        for (Long id : classDatas.keySet()) {
+            ClassData cd = classDatas.get(id);
+            finalClassCounts.add(cd, classCounts.count(id));
         }
 
         if (verboseOut != null) {

--- a/jol-core/src/main/java/org/openjdk/jol/heap/HeapDumpReader.java
+++ b/jol-core/src/main/java/org/openjdk/jol/heap/HeapDumpReader.java
@@ -27,6 +27,7 @@ package org.openjdk.jol.heap;
 import org.openjdk.jol.info.ClassData;
 import org.openjdk.jol.info.FieldData;
 import org.openjdk.jol.util.ClassUtils;
+import org.openjdk.jol.util.Multimap;
 import org.openjdk.jol.util.Multiset;
 
 import java.io.*;
@@ -51,8 +52,10 @@ public class HeapDumpReader {
 
     private final Map<Long, String> strings;
     private final Map<Long, String> classNames;
-    private final Multiset<ClassData> classCounts;
-    private final Map<Long, ClassData> classDatas;
+    private final Multimap<Long, FieldData> classFields;
+    private final Multiset<Long> classCounts;
+    private final Multiset<ClassData> arrayCounts;
+    private final Map<Long, Long> classSupers;
     private final File file;
     private final PrintStream verboseOut;
     private final Visitor visitor;
@@ -76,7 +79,9 @@ public class HeapDumpReader {
         this.strings = new HashMap<>();
         this.classNames = new HashMap<>();
         this.classCounts = new Multiset<>();
-        this.classDatas = new HashMap<>();
+        this.classFields = new Multimap<>();
+        this.arrayCounts = new Multiset<>();
+        this.classSupers = new HashMap<>();
         this.buf = new byte[32*1024];
         this.wrapBuf = ByteBuffer.wrap(buf);
     }
@@ -174,11 +179,39 @@ public class HeapDumpReader {
             }
         }
 
+        // Post-process supers: merge all fields datas up the class hierarchy.
+        Map<Long, ClassData> classDatas = new HashMap<>();
+
+        for (Long klassId : classFields.keys()) {
+            ClassData cd = new ClassData(classNames.get(klassId));
+
+            Long id = klassId;
+            while (id != null) {
+                cd.addSuperClass(classNames.get(id));
+                for (FieldData fd : classFields.get(id)) {
+                    cd.addField(fd);
+                }
+                id = classSupers.get(id);
+            }
+            classDatas.put(klassId, cd);
+        }
+
+        // Compute final class counts.
+        Multiset<ClassData> finalClassCounts = new Multiset<>();
+        for (ClassData cd : arrayCounts.keys()) {
+            finalClassCounts.add(cd, arrayCounts.count(cd));
+        }
+        for (Long klassId : classDatas.keySet()) {
+            ClassData cd = classDatas.get(klassId);
+            long count = classCounts.count(klassId);
+            finalClassCounts.add(cd, count);
+        }
+
         if (verboseOut != null) {
             verboseOut.println("DONE");
         }
 
-        return classCounts;
+        return finalClassCounts;
     }
 
     private void digestHeapDump() throws HeapDumpException {
@@ -241,7 +274,7 @@ public class HeapDumpReader {
         int typeClass = read_U1();
 
         String typeString = getTypeString(typeClass);
-        classCounts.add(new ClassData(typeString + "[]", typeString, elements));
+        arrayCounts.add(new ClassData(typeString + "[]", typeString, elements));
 
         int len = elements * getSize(typeClass);
         if (visitor != null) {
@@ -263,7 +296,7 @@ public class HeapDumpReader {
 
         // Assume Object as component type, the name of the actual class
         // is what we want for the printouts.
-        classCounts.add(new ClassData(name, "Object", elements));
+        arrayCounts.add(new ClassData(name, "Object", elements));
     }
 
     private void digestInstance() throws HeapDumpException {
@@ -271,7 +304,7 @@ public class HeapDumpReader {
         read_U4(); // stack trace
         long klassID = read_ID();
 
-        classCounts.add(classDatas.get(klassID));
+        classCounts.add(klassID);
 
         int instanceBytes = (int) read_U4(); // always fits
 
@@ -288,15 +321,11 @@ public class HeapDumpReader {
 
         String name = classNames.get(klassID);
 
-        ClassData cd = new ClassData(name);
-        cd.addSuperClass(name);
-
         read_U4(); // stack trace
 
         long superKlassID = read_ID();
-        ClassData superCd = classDatas.get(superKlassID);
-        if (superCd != null) {
-            cd.merge(superCd);
+        if (superKlassID != 0 && classSupers.put(klassID, superKlassID) != null) {
+            throw new HeapDumpException("Format error: duplicate class " + name);
         }
 
         read_ID(); // class loader
@@ -328,14 +357,12 @@ public class HeapDumpReader {
             long index = read_ID();
             int type = read_U1();
 
-            cd.addField(FieldData.create(name, strings.get(index), getTypeString(type)));
+            classFields.put(klassID, FieldData.create(name, strings.get(index), getTypeString(type)));
             if (type == 2) {
                 oopIdx.add(offset);
             }
             offset += getSize(type);
         }
-
-        classDatas.put(klassID, cd);
 
         if (visitor != null) {
             visitor.visitClass(klassID, name, oopIdx, idSize);

--- a/jol-core/src/main/java/org/openjdk/jol/info/ClassData.java
+++ b/jol-core/src/main/java/org/openjdk/jol/info/ClassData.java
@@ -372,16 +372,6 @@ public class ClassData {
         return length;
     }
 
-    /**
-     * Merge this class data with the super-class class data
-     *
-     * @param superClassData super class data
-     */
-    public void merge(ClassData superClassData) {
-        fields.addAll(superClassData.fields);
-        classNames.addAll(0, superClassData.classNames);
-    }
-
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/jol-core/src/main/java/org/openjdk/jol/util/Multimap.java
+++ b/jol-core/src/main/java/org/openjdk/jol/util/Multimap.java
@@ -46,7 +46,11 @@ public class Multimap<K, V> {
     }
 
     public List<V> get(K k) {
-        return Collections.unmodifiableList(map.get(k));
+        if (map.containsKey(k)) {
+            return Collections.unmodifiableList(map.get(k));
+        } else {
+            return Collections.emptyList();
+        }
     }
 
     public Collection<K> keys() {


### PR DESCRIPTION
Current heap dump parser relies on class records to appear after the superclass records appear. This does not actually hold for hprof: we can emit the subclass records first, and only then emit the superclass records.

Therefore, current heap dump reader is broken when it encounters hierarchical classes. If the superclass was not seen before current class is being parsed, the heap dump reader would silently treat the current class as having _no super klasses_ at all. It would then underestimate the class footprint, because it does not record superclasses.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903579](https://bugs.openjdk.org/browse/CODETOOLS-7903579): JOL: Heap dump parser handles superclasses incorrectly (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jol.git pull/53/head:pull/53` \
`$ git checkout pull/53`

Update a local copy of the PR: \
`$ git checkout pull/53` \
`$ git pull https://git.openjdk.org/jol.git pull/53/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 53`

View PR using the GUI difftool: \
`$ git pr show -t 53`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jol/pull/53.diff">https://git.openjdk.org/jol/pull/53.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jol/pull/53#issuecomment-1807983835)