### PR TITLE
7903583: JOL: Heap dump parser misses superclasses with empty fields

### DIFF
--- a/jol-core/src/main/java/org/openjdk/jol/heap/HeapDumpReader.java
+++ b/jol-core/src/main/java/org/openjdk/jol/heap/HeapDumpReader.java
@@ -200,9 +200,12 @@ public class HeapDumpReader {
         for (Long klassId : classDatas.keySet()) {
             Long key = classSupers.get(klassId);
             if (key != null) {
+                ClassData cd = classDatas.get(klassId);
                 ClassData superCd = classDatas.get(key);
-                ClassData thisCd = classDatas.get(klassId);
-                thisCd.addSuperClassData(superCd);
+                if (superCd == null) {
+                    throw new IllegalStateException("Parser error: no super class data for " + cd.name() + " (" + key + ")");
+                }
+                cd.addSuperClassData(superCd);
             }
         }
 
@@ -371,6 +374,9 @@ public class HeapDumpReader {
                 oopIdx.add(offset);
             }
             offset += getSize(type);
+        }
+        if (cpInstance == 0) {
+            classFields.putEmpty(klassID);
         }
 
         if (visitor != null) {

--- a/jol-core/src/main/java/org/openjdk/jol/info/FieldData.java
+++ b/jol-core/src/main/java/org/openjdk/jol/info/FieldData.java
@@ -168,6 +168,6 @@ public class FieldData {
 
     @Override
     public String toString() {
-        return name + ": " + type;
+        return klass + "." + name + ": " + type;
     }
 }

--- a/jol-core/src/main/java/org/openjdk/jol/util/Multimap.java
+++ b/jol-core/src/main/java/org/openjdk/jol/util/Multimap.java
@@ -45,6 +45,14 @@ public class Multimap<K, V> {
         vs.add(v);
     }
 
+    public void putEmpty(K k) {
+        List<V> vs = map.get(k);
+        if (vs == null) {
+            vs = new ArrayList<>();
+            map.put(k, vs);
+        }
+    }
+
     public List<V> get(K k) {
         if (map.containsKey(k)) {
             return Collections.unmodifiableList(map.get(k));

--- a/jol-core/src/test/java/org/openjdk/jol/info/ClassDataTest.java
+++ b/jol-core/src/test/java/org/openjdk/jol/info/ClassDataTest.java
@@ -11,23 +11,25 @@ public class ClassDataTest {
 
   private final ClassData classData = ClassData.parseClass(Class3.class);
 
+  private static final String PREFIX = "org.openjdk.jol.info.ClassDataTest.Class";
+
   static class Class1 {
-    int c1f1;
-    int c1f2;
-    int c1f3;
+    int f1;
+    int f2;
+    int f3;
   }
 
   static class Class2 extends Class1 {
-    int c2f1;
-    int c2f2;
-    int c2f3;
+    int f1;
+    int f2;
+    int f3;
   }
 
   static class Class3 extends Class2 {
-    int c3f1;
-    int c3f2;
-    int c3f3;
-    Object c3f4;
+    int f1;
+    int f2;
+    int f3;
+    Object f4;
   }
 
   @Test
@@ -42,7 +44,7 @@ public class ClassDataTest {
     String klass3 = Class3.class.getCanonicalName();
 
     assertEquals(4, ownFields.size());
-    assertEquals("[c3f1: int, c3f2: int, c3f3: int, c3f4: java.lang.Object]", ownFields.toString());
+    assertEquals("[" + PREFIX + "3.f1: int, " +  PREFIX + "3.f2: int, " + PREFIX + "3.f3: int, " + PREFIX + "3.f4: java.lang.Object]", ownFields.toString());
   }
 
   @Test
@@ -59,7 +61,7 @@ public class ClassDataTest {
     assertEquals(klass, classFields.get(0).hostClass());
     assertEquals(klass, classFields.get(1).hostClass());
     assertEquals(klass, classFields.get(2).hostClass());
-    assertEquals("[c1f1: int, c1f2: int, c1f3: int]", classFields.toString());
+    assertEquals("[" + PREFIX + "1.f1: int, " + PREFIX + "1.f2: int, " + PREFIX + "1.f3: int]", classFields.toString());
   }
 
   @Test
@@ -70,7 +72,7 @@ public class ClassDataTest {
     assertEquals(klass, classFields.get(0).hostClass());
     assertEquals(klass, classFields.get(1).hostClass());
     assertEquals(klass, classFields.get(2).hostClass());
-    assertEquals("[c2f1: int, c2f2: int, c2f3: int]", classFields.toString());
+    assertEquals("[" + PREFIX + "2.f1: int, " + PREFIX + "2.f2: int, " + PREFIX + "2.f3: int]", classFields.toString());
   }
 
   @Test
@@ -82,7 +84,7 @@ public class ClassDataTest {
     assertEquals(klass, classFields.get(1).hostClass());
     assertEquals(klass, classFields.get(2).hostClass());
     assertEquals(klass, classFields.get(3).hostClass());
-    assertEquals("[c3f1: int, c3f2: int, c3f3: int, c3f4: java.lang.Object]", classFields.toString());
+    assertEquals("[" + PREFIX + "3.f1: int, " +  PREFIX + "3.f2: int, " + PREFIX + "3.f3: int, " + PREFIX + "3.f4: java.lang.Object]", classFields.toString());
   }
 
   @Test


### PR DESCRIPTION
[CODETOOLS-7903579](https://bugs.openjdk.org/browse/CODETOOLS-7903579) was not complete for old layouter. There are still problems when superclasses do not have fields.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903583](https://bugs.openjdk.org/browse/CODETOOLS-7903583): JOL: Heap dump parser misses superclasses with empty fields (**Enhancement** - P4)


### Reviewers
 * @stokito (no known openjdk.org user name / role) ⚠️ Review applies to [3f7a88fc](https://git.openjdk.org/jol/pull/54/files/3f7a88fcd95b615c7b7b5787838b55bae8c18cfb)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jol.git pull/54/head:pull/54` \
`$ git checkout pull/54`

Update a local copy of the PR: \
`$ git checkout pull/54` \
`$ git pull https://git.openjdk.org/jol.git pull/54/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 54`

View PR using the GUI difftool: \
`$ git pr show -t 54`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jol/pull/54.diff">https://git.openjdk.org/jol/pull/54.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jol/pull/54#issuecomment-1816136532)