### PR TITLE
7903643: JOL: heapdump-duplicates does not print small array contents with non-power-of-2 sizes

### DIFF
--- a/jol-cli/src/main/java/org/openjdk/jol/operations/HeapDumpDuplicates.java
+++ b/jol-cli/src/main/java/org/openjdk/jol/operations/HeapDumpDuplicates.java
@@ -254,15 +254,19 @@ public class HeapDumpDuplicates implements Operation {
                         case 8:
                             sb.append((contents >> 56) & 0xFF);
                             sb.append(", ");
+                        case 7:
                             sb.append((contents >> 48) & 0xFF);
                             sb.append(", ");
+                        case 6:
                             sb.append((contents >> 40) & 0xFF);
                             sb.append(", ");
+                        case 5:
                             sb.append((contents >> 32) & 0xFF);
                             sb.append(", ");
                         case 4:
                             sb.append((contents >> 24) & 0xFF);
                             sb.append(", ");
+                        case 3:
                             sb.append((contents >> 16) & 0xFF);
                             sb.append(", ");
                         case 2:
@@ -277,6 +281,7 @@ public class HeapDumpDuplicates implements Operation {
                         case 4:
                             sb.append((contents >> 48) & 0xFFFF);
                             sb.append(", ");
+                        case 3:
                             sb.append((contents >> 32) & 0xFFFF);
                             sb.append(", ");
                         case 2:


### PR DESCRIPTION
Clearly visible in reports:

```
            DUPS SIZE VALUE
------------------------------------------------------------------------------------------------
           5.955 390.219.240 byte[...] { 0, ..., 0 }
           1.824 119.566.848 byte[...] { 0, ..., 0 }
       1.666.703 40.000.872 byte[3] { }
       1.269.514 30.468.336 byte[3] { }
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903643](https://bugs.openjdk.org/browse/CODETOOLS-7903643): JOL: heapdump-duplicates does not print small array contents with non-power-of-2 sizes (**Bug** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jol.git pull/56/head:pull/56` \
`$ git checkout pull/56`

Update a local copy of the PR: \
`$ git checkout pull/56` \
`$ git pull https://git.openjdk.org/jol.git pull/56/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 56`

View PR using the GUI difftool: \
`$ git pr show -t 56`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jol/pull/56.diff">https://git.openjdk.org/jol/pull/56.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jol/pull/56#issuecomment-1910222434)