### PR TITLE
7903652: JOL: Fix empty arrays visualization in LJV

### DIFF
--- a/jol-core/src/main/java/org/openjdk/jol/ljv/GraphvizVisualization.java
+++ b/jol-core/src/main/java/org/openjdk/jol/ljv/GraphvizVisualization.java
@@ -84,8 +84,10 @@ public class GraphvizVisualization implements Visualization {
         } else {
             out.append("\t\t<table border='0' cellborder='1' cellspacing='0' cellpadding='9'>\n");
         }
-
         out.append("\t\t\t<tr>\n");
+        out.append("\t\t\t\t<td>");
+        out.append(arrayNode.getClassName());
+        out.append("</td>\n");
     }
 
     @Override

--- a/jol-core/src/main/java/org/openjdk/jol/ljv/IntrospectionWithReflectionAPI.java
+++ b/jol-core/src/main/java/org/openjdk/jol/ljv/IntrospectionWithReflectionAPI.java
@@ -59,7 +59,9 @@ public class IntrospectionWithReflectionAPI implements Introspection {
         }
 
         if (obj.getClass().isArray()) {
-            ArrayNode arrayNode = new ArrayNode(obj, name, canTreatObjAsArrayOfPrimitives(obj), getArrayContent(obj));
+            ArrayNode arrayNode = new ArrayNode(obj, name,
+                    getObjClassName(obj, false),
+                    canTreatObjAsArrayOfPrimitives(obj), getArrayContent(obj));
             if (field != null) {
                 arrayNode.setAttributes(ljv.getFieldAttributes(field, obj));
             }
@@ -120,10 +122,16 @@ public class IntrospectionWithReflectionAPI implements Introspection {
     public String getObjClassName(Object obj, boolean useToStringAsClassName) {
         if (obj == null)
             return "";
-
-        Class<?> c = obj.getClass();
         if (useToStringAsClassName && canBeConvertedToString(obj))
             return Quote.quote(obj.toString());
+        else {
+            return getClassName(obj.getClass());
+        }
+    }
+
+    private String getClassName(Class<?> c) {
+        if (c.isArray())
+            return getClassName(c.getComponentType()) + "[]";
         else {
             String name = c.getName();
             if (!ljv.isShowPackageNamesInClasses() || c.getPackage() == ljv.getClass().getPackage()) {

--- a/jol-core/src/main/java/org/openjdk/jol/ljv/nodes/ArrayNode.java
+++ b/jol-core/src/main/java/org/openjdk/jol/ljv/nodes/ArrayNode.java
@@ -34,8 +34,11 @@ public class ArrayNode extends Node {
     private final boolean valuesArePrimitive;
     private final List<Node> content;
 
-    public ArrayNode(Object obj, String name, boolean valuesArePrimitive, List<Node> content) {
+    private final String className;
+
+    public ArrayNode(Object obj, String name, String className, boolean valuesArePrimitive, List<Node> content) {
         super(obj, name);
+        this.className = className;
         this.valuesArePrimitive = valuesArePrimitive;
         this.content = content;
     }
@@ -65,5 +68,9 @@ public class ArrayNode extends Node {
             }
             v.visitArrayElementObjectConnection(getValue(), i, node.getValue());
         }
+    }
+
+    public String getClassName() {
+        return className;
     }
 }

--- a/jol-core/src/test/java/org/openjdk/jol/ljv/LJVTest.java
+++ b/jol-core/src/test/java/org/openjdk/jol/ljv/LJVTest.java
@@ -40,14 +40,14 @@ import static org.junit.Assume.assumeTrue;
 public class LJVTest extends VersionGuardedTest {
     @Test
     public void stringIsNotAPrimitiveType() {
-        assumeTrue(is11());
+        assumeTrue(is8());
         String actualGraph = new LJV().drawGraph("Hello");
         Approvals.verify(actualGraph);
     }
 
     @Test
     public void objectArraysHoldReferencesPrimitiveArraysHoldValues() {
-        assumeTrue(is11());
+        assumeTrue(is8());
         String actual_graph = new LJV()
                 .setTreatAsPrimitive(String.class)
                 .setIgnorePrivateFields(false)
@@ -59,7 +59,7 @@ public class LJVTest extends VersionGuardedTest {
 
     @Test
     public void assignmentDoesNotCreateANewObject() {
-        assumeTrue(is11());
+        assumeTrue(is8());
         String x = "Hello";
         String y = x;
         String actual_graph = new LJV().drawGraph(new Object[]{x, y});
@@ -68,7 +68,7 @@ public class LJVTest extends VersionGuardedTest {
 
     @Test
     public void assignmentWithNewCreateANewObject() {
-        assumeTrue(is11());
+        assumeTrue(is8());
         String x = "Hello";
         String y = new String(x);
         String actual_graph = new LJV().drawGraph(new Object[]{x, y});
@@ -77,7 +77,7 @@ public class LJVTest extends VersionGuardedTest {
 
     @Test
     public void stringIntern() {
-        assumeTrue(is11());
+        assumeTrue(is8());
         String x = "Hello";
         String y = "Hello";
         String actual_graph = new LJV().drawGraph(new Object[]{x, y.intern()});
@@ -86,21 +86,21 @@ public class LJVTest extends VersionGuardedTest {
 
     @Test
     public void multiDimensionalArrays() {
-        assumeTrue(is11());
+        assumeTrue(is8());
         String actual_graph = new LJV().drawGraph(new int[4][5]);
         Approvals.verify(actual_graph);
     }
 
     @Test
     public void reversedMultiDimensionalArrays() {
-        assumeTrue(is11());
+        assumeTrue(is8());
         String actual_graph = new LJV().setDirection(Direction.LR).drawGraph(new int[4][5]);
         Approvals.verify(actual_graph);
     }
 
     @Test
     public void cyclicalStructuresClassesWithAndWithoutAToStringAndWithoutContext() {
-        assumeTrue(is11());
+        assumeTrue(is8());
         Node n1 = new Node("A");
         n1.level = 1;
         AnotherNode n2 = new AnotherNode("B");
@@ -125,7 +125,7 @@ public class LJVTest extends VersionGuardedTest {
 
     @Test
     public void paulsExample() {
-        assumeTrue(is11());
+        assumeTrue(is8());
         ArrayList<Object> a = new ArrayList<>();
         a.add(new Person("Albert", Gender.MALE, 35));
         a.add(new Person("Betty", Gender.FEMALE, 20));
@@ -143,7 +143,7 @@ public class LJVTest extends VersionGuardedTest {
 
     @Test
     public void multipleRoots() {
-        assumeTrue(is11());
+        assumeTrue(is8());
         ArrayList<Object> a = new ArrayList<>();
         Person p = new Person("Albert", Gender.MALE, 35);
         Person p2 = new Person("Albert", Gender.MALE, 35);
@@ -153,21 +153,26 @@ public class LJVTest extends VersionGuardedTest {
 
     @Test
     public void testNull() {
-        assumeTrue(is11());
         String actualGraph = new LJV().drawGraph(null);
         Approvals.verify(actualGraph);
     }
 
     @Test
+    public void testEmptyArray() {
+        String dot = new LJV().drawGraph(new int[0][0]);
+        Approvals.verify(dot);
+    }
+
+    @Test
     public void testMultiNull() {
-        assumeTrue(is11());
+        assumeTrue(is8());
         String actualGraph = new LJV().addRoot(null).addRoot(null).drawGraph();
         Approvals.verify(actualGraph);
     }
 
     @Test
     public void testMixedNullsAndNotNulls() {
-        assumeTrue(is11());
+        assumeTrue(is8());
         String actualGraph = new LJV().addRoot(null)
                 .addRoot(new Object()).addRoot(new Object()).addRoot(null).drawGraph();
         Approvals.verify(actualGraph);
@@ -175,7 +180,7 @@ public class LJVTest extends VersionGuardedTest {
 
     @Test
     public void treeMap() {
-        assumeTrue(is11());
+        assumeTrue(is8());
         TreeMap<String, Integer> map = new TreeMap<>();
 
         map.put("one", 1);
@@ -224,7 +229,7 @@ public class LJVTest extends VersionGuardedTest {
 
     @Test
     public void linkedHashMap() {
-        assumeTrue(is11());
+        assumeTrue(is8());
         LinkedHashMap<String, Integer> map = new LinkedHashMap<>();
         map.put("one", 1);
         map.put("two", 2);
@@ -242,7 +247,7 @@ public class LJVTest extends VersionGuardedTest {
 
     @Test
     public void hashMap() {
-        assumeTrue(is11());
+        assumeTrue(is8());
         HashMap<String, Integer> map = new HashMap<>();
         map.put("one", 1);
         map.put("two", 2);
@@ -259,7 +264,7 @@ public class LJVTest extends VersionGuardedTest {
 
     @Test
     public void hashMapCollision2() {
-        assumeTrue(is11());
+        assumeTrue(is8());
         List<String> collisionString = new HashCodeCollision().genCollisionString(8);
         HashMap<String, Integer> map = new HashMap<>();
 
@@ -278,14 +283,14 @@ public class LJVTest extends VersionGuardedTest {
 
     @Test
     public void wrappedObjects() {
-        assumeTrue(is11());
+        assumeTrue(is8());
         String actual_graph = new LJV().drawGraph(new Example());
         Approvals.verify(actual_graph);
     }
 
     @Test
     public void linkedList() {
-        assumeTrue(is11());
+        assumeTrue(is8());
         LinkedList<Integer> linkedList = new LinkedList<>();
         linkedList.add(1);
         linkedList.add(42);
@@ -303,7 +308,7 @@ public class LJVTest extends VersionGuardedTest {
 
     @Test
     public void testArrayWithHighlighting() {
-        assumeTrue(is11());
+        assumeTrue(is8());
         LJV ljv = new LJV()
                 .setTreatAsPrimitive(Integer.class)
                 .highlightChangingArrayElements();
@@ -319,7 +324,7 @@ public class LJVTest extends VersionGuardedTest {
 
     @Test
     public void testNewObjectsHighlighting() {
-        assumeTrue(is11());
+        assumeTrue(is8());
         LJV ljv = new LJV()
                 .setTreatAsPrimitive(Integer.class)
                 .setTreatAsPrimitive(String.class)
@@ -338,7 +343,7 @@ public class LJVTest extends VersionGuardedTest {
 
     @Test
     public void arrayWithFieldAttribute() {
-        assumeTrue(is11());
+        assumeTrue(is8());
         String actualGraph = new LJV()
                 .addFieldAttribute("value", "color=red,fontcolor=red")
                 .drawGraph("Hello");
@@ -347,7 +352,7 @@ public class LJVTest extends VersionGuardedTest {
 
     @Test
     public void twoObjectsLinksToOneArray() {
-        assumeTrue(is11());
+        assumeTrue(is8());
         int[] arr = {1, 2, 3};
         A x = new A(arr);
         B y = new B(arr);
@@ -361,7 +366,7 @@ public class LJVTest extends VersionGuardedTest {
 
     @Test
     public void arrayItemLinksToArray() {
-        assumeTrue(is11());
+        assumeTrue(is8());
         ArrayItem child = new ArrayItem();
         ArrayItem[] array = {child};
         child.prev = array;

--- a/jol-core/src/test/java/org/openjdk/jol/ljv/VersionGuardedTest.java
+++ b/jol-core/src/test/java/org/openjdk/jol/ljv/VersionGuardedTest.java
@@ -27,8 +27,8 @@ package org.openjdk.jol.ljv;
 public class VersionGuardedTest {
     int VERSION = getVersion();
 
-    public boolean is11() {
-        return VERSION == 11;
+    public boolean is8() {
+        return VERSION == 8;
     }
 
     static int getVersion() {

--- a/jol-core/src/test/java/org/openjdk/jol/ljv/approvals/LJVTest.arrayItemLinksToArray.approved.txt
+++ b/jol-core/src/test/java/org/openjdk/jol/ljv/approvals/LJVTest.arrayItemLinksToArray.approved.txt
@@ -4,6 +4,7 @@ digraph Java {
 	n1[label=<
 		<table border='0' cellborder='1' cellspacing='0' cellpadding='9'>
 			<tr>
+				<td>ArrayItem[]</td>
 				<td port="f0"></td>
 			</tr>
 		</table>

--- a/jol-core/src/test/java/org/openjdk/jol/ljv/approvals/LJVTest.arrayWithFieldAttribute.approved.txt
+++ b/jol-core/src/test/java/org/openjdk/jol/ljv/approvals/LJVTest.arrayWithFieldAttribute.approved.txt
@@ -4,24 +4,22 @@ digraph Java {
 	n1[label=<
 		<table border='0' cellborder='1' cellspacing='0'>
 			<tr>
-				<td rowspan='3'>String</td>
+				<td rowspan='2'>String</td>
 			</tr>
 			<tr>
 				<td>hash: 0</td>
-			</tr>
-			<tr>
-				<td>coder: 0</td>
 			</tr>
 		</table>
 	>];
 	n2[label=<
 		<table border='0' cellborder='1' cellspacing='0'>
 			<tr>
-				<td>72</td>
-				<td>101</td>
-				<td>108</td>
-				<td>108</td>
-				<td>111</td>
+				<td>char[]</td>
+				<td>H</td>
+				<td>e</td>
+				<td>l</td>
+				<td>l</td>
+				<td>o</td>
 			</tr>
 		</table>
 	>];

--- a/jol-core/src/test/java/org/openjdk/jol/ljv/approvals/LJVTest.assignmentDoesNotCreateANewObject.approved.txt
+++ b/jol-core/src/test/java/org/openjdk/jol/ljv/approvals/LJVTest.assignmentDoesNotCreateANewObject.approved.txt
@@ -4,6 +4,7 @@ digraph Java {
 	n1[label=<
 		<table border='0' cellborder='1' cellspacing='0' cellpadding='9'>
 			<tr>
+				<td>Object[]</td>
 				<td port="f0"></td>
 				<td port="f1"></td>
 			</tr>
@@ -12,24 +13,22 @@ digraph Java {
 	n2[label=<
 		<table border='0' cellborder='1' cellspacing='0'>
 			<tr>
-				<td rowspan='3'>String</td>
+				<td rowspan='2'>String</td>
 			</tr>
 			<tr>
 				<td>hash: 0</td>
-			</tr>
-			<tr>
-				<td>coder: 0</td>
 			</tr>
 		</table>
 	>];
 	n3[label=<
 		<table border='0' cellborder='1' cellspacing='0'>
 			<tr>
-				<td>72</td>
-				<td>101</td>
-				<td>108</td>
-				<td>108</td>
-				<td>111</td>
+				<td>char[]</td>
+				<td>H</td>
+				<td>e</td>
+				<td>l</td>
+				<td>l</td>
+				<td>o</td>
 			</tr>
 		</table>
 	>];

--- a/jol-core/src/test/java/org/openjdk/jol/ljv/approvals/LJVTest.assignmentWithNewCreateANewObject.approved.txt
+++ b/jol-core/src/test/java/org/openjdk/jol/ljv/approvals/LJVTest.assignmentWithNewCreateANewObject.approved.txt
@@ -4,6 +4,7 @@ digraph Java {
 	n1[label=<
 		<table border='0' cellborder='1' cellspacing='0' cellpadding='9'>
 			<tr>
+				<td>Object[]</td>
 				<td port="f0"></td>
 				<td port="f1"></td>
 			</tr>
@@ -12,24 +13,22 @@ digraph Java {
 	n2[label=<
 		<table border='0' cellborder='1' cellspacing='0'>
 			<tr>
-				<td rowspan='3'>String</td>
+				<td rowspan='2'>String</td>
 			</tr>
 			<tr>
 				<td>hash: 0</td>
-			</tr>
-			<tr>
-				<td>coder: 0</td>
 			</tr>
 		</table>
 	>];
 	n3[label=<
 		<table border='0' cellborder='1' cellspacing='0'>
 			<tr>
-				<td>72</td>
-				<td>101</td>
-				<td>108</td>
-				<td>108</td>
-				<td>111</td>
+				<td>char[]</td>
+				<td>H</td>
+				<td>e</td>
+				<td>l</td>
+				<td>l</td>
+				<td>o</td>
 			</tr>
 		</table>
 	>];
@@ -38,13 +37,10 @@ digraph Java {
 	n4[label=<
 		<table border='0' cellborder='1' cellspacing='0'>
 			<tr>
-				<td rowspan='3'>String</td>
+				<td rowspan='2'>String</td>
 			</tr>
 			<tr>
 				<td>hash: 0</td>
-			</tr>
-			<tr>
-				<td>coder: 0</td>
 			</tr>
 		</table>
 	>];

--- a/jol-core/src/test/java/org/openjdk/jol/ljv/approvals/LJVTest.hashMap.approved.txt
+++ b/jol-core/src/test/java/org/openjdk/jol/ljv/approvals/LJVTest.hashMap.approved.txt
@@ -23,6 +23,7 @@ digraph Java {
 	n2[label=<
 		<table border='0' cellborder='1' cellspacing='0' cellpadding='9'>
 			<tr>
+				<td>Node[]</td>
 				<td port="f0"></td>
 				<td port="f1"></td>
 				<td port="f2"></td>

--- a/jol-core/src/test/java/org/openjdk/jol/ljv/approvals/LJVTest.hashMapCollision2.approved.txt
+++ b/jol-core/src/test/java/org/openjdk/jol/ljv/approvals/LJVTest.hashMapCollision2.approved.txt
@@ -32,6 +32,7 @@ digraph Java {
 	n2[label=<
 		<table border='0' cellborder='1' cellspacing='0' cellpadding='9'>
 			<tr>
+				<td>Node[]</td>
 				<td port="f0"></td>
 				<td port="f1"></td>
 				<td port="f2"></td>

--- a/jol-core/src/test/java/org/openjdk/jol/ljv/approvals/LJVTest.linkedHashMap.approved.txt
+++ b/jol-core/src/test/java/org/openjdk/jol/ljv/approvals/LJVTest.linkedHashMap.approved.txt
@@ -26,6 +26,7 @@ digraph Java {
 	n2[label=<
 		<table border='0' cellborder='1' cellspacing='0' cellpadding='9'>
 			<tr>
+				<td>Node[]</td>
 				<td port="f0"></td>
 				<td port="f1"></td>
 				<td port="f2"></td>

--- a/jol-core/src/test/java/org/openjdk/jol/ljv/approvals/LJVTest.multiDimensionalArrays.approved.txt
+++ b/jol-core/src/test/java/org/openjdk/jol/ljv/approvals/LJVTest.multiDimensionalArrays.approved.txt
@@ -4,6 +4,7 @@ digraph Java {
 	n1[label=<
 		<table border='0' cellborder='1' cellspacing='0' cellpadding='9'>
 			<tr>
+				<td>int[][]</td>
 				<td port="f0"></td>
 				<td port="f1"></td>
 				<td port="f2"></td>
@@ -14,6 +15,7 @@ digraph Java {
 	n2[label=<
 		<table border='0' cellborder='1' cellspacing='0'>
 			<tr>
+				<td>int[]</td>
 				<td>0</td>
 				<td>0</td>
 				<td>0</td>
@@ -26,6 +28,7 @@ digraph Java {
 	n3[label=<
 		<table border='0' cellborder='1' cellspacing='0'>
 			<tr>
+				<td>int[]</td>
 				<td>0</td>
 				<td>0</td>
 				<td>0</td>
@@ -38,6 +41,7 @@ digraph Java {
 	n4[label=<
 		<table border='0' cellborder='1' cellspacing='0'>
 			<tr>
+				<td>int[]</td>
 				<td>0</td>
 				<td>0</td>
 				<td>0</td>
@@ -50,6 +54,7 @@ digraph Java {
 	n5[label=<
 		<table border='0' cellborder='1' cellspacing='0'>
 			<tr>
+				<td>int[]</td>
 				<td>0</td>
 				<td>0</td>
 				<td>0</td>

--- a/jol-core/src/test/java/org/openjdk/jol/ljv/approvals/LJVTest.multipleRoots.approved.txt
+++ b/jol-core/src/test/java/org/openjdk/jol/ljv/approvals/LJVTest.multipleRoots.approved.txt
@@ -14,25 +14,23 @@ digraph Java {
 	n2[label=<
 		<table border='0' cellborder='1' cellspacing='0'>
 			<tr>
-				<td rowspan='3'>String</td>
+				<td rowspan='2'>String</td>
 			</tr>
 			<tr>
 				<td>hash: 0</td>
-			</tr>
-			<tr>
-				<td>coder: 0</td>
 			</tr>
 		</table>
 	>];
 	n3[label=<
 		<table border='0' cellborder='1' cellspacing='0'>
 			<tr>
-				<td>65</td>
-				<td>108</td>
-				<td>98</td>
-				<td>101</td>
-				<td>114</td>
-				<td>116</td>
+				<td>char[]</td>
+				<td>A</td>
+				<td>l</td>
+				<td>b</td>
+				<td>e</td>
+				<td>r</td>
+				<td>t</td>
 			</tr>
 		</table>
 	>];
@@ -51,23 +49,21 @@ digraph Java {
 	n5[label=<
 		<table border='0' cellborder='1' cellspacing='0'>
 			<tr>
-				<td rowspan='3'>String</td>
+				<td rowspan='2'>String</td>
 			</tr>
 			<tr>
 				<td>hash: 0</td>
-			</tr>
-			<tr>
-				<td>coder: 0</td>
 			</tr>
 		</table>
 	>];
 	n6[label=<
 		<table border='0' cellborder='1' cellspacing='0'>
 			<tr>
-				<td>77</td>
-				<td>65</td>
-				<td>76</td>
-				<td>69</td>
+				<td>char[]</td>
+				<td>M</td>
+				<td>A</td>
+				<td>L</td>
+				<td>E</td>
 			</tr>
 		</table>
 	>];

--- a/jol-core/src/test/java/org/openjdk/jol/ljv/approvals/LJVTest.objectArraysHoldReferencesPrimitiveArraysHoldValues.approved.txt
+++ b/jol-core/src/test/java/org/openjdk/jol/ljv/approvals/LJVTest.objectArraysHoldReferencesPrimitiveArraysHoldValues.approved.txt
@@ -4,6 +4,7 @@ digraph Java {
 	n1[label=<
 		<table border='0' cellborder='1' cellspacing='0' cellpadding='9'>
 			<tr>
+				<td>Object[]</td>
 				<td port="f0"></td>
 				<td port="f1"></td>
 			</tr>
@@ -12,6 +13,7 @@ digraph Java {
 	n2[label=<
 		<table border='0' cellborder='1' cellspacing='0'>
 			<tr>
+				<td>String[]</td>
 				<td>a</td>
 				<td>b</td>
 				<td>c</td>
@@ -22,6 +24,7 @@ digraph Java {
 	n3[label=<
 		<table border='0' cellborder='1' cellspacing='0'>
 			<tr>
+				<td>int[]</td>
 				<td>1</td>
 				<td>2</td>
 				<td>3</td>

--- a/jol-core/src/test/java/org/openjdk/jol/ljv/approvals/LJVTest.paulsExample.approved.txt
+++ b/jol-core/src/test/java/org/openjdk/jol/ljv/approvals/LJVTest.paulsExample.approved.txt
@@ -17,6 +17,7 @@ digraph Java {
 	n2[label=<
 		<table border='0' cellborder='1' cellspacing='0' cellpadding='9'>
 			<tr>
+				<td>Object[]</td>
 				<td port="f0"></td>
 				<td port="f1"></td>
 				<td port="f2"></td>

--- a/jol-core/src/test/java/org/openjdk/jol/ljv/approvals/LJVTest.reversedMultiDimensionalArrays.approved.txt
+++ b/jol-core/src/test/java/org/openjdk/jol/ljv/approvals/LJVTest.reversedMultiDimensionalArrays.approved.txt
@@ -4,6 +4,7 @@ digraph Java {
 	n1[label=<
 		<table border='0' cellborder='1' cellspacing='0' cellpadding='9'>
 			<tr>
+				<td>int[][]</td>
 				<td port="f0"></td>
 				<td port="f1"></td>
 				<td port="f2"></td>
@@ -14,6 +15,7 @@ digraph Java {
 	n2[label=<
 		<table border='0' cellborder='1' cellspacing='0'>
 			<tr>
+				<td>int[]</td>
 				<td>0</td>
 				<td>0</td>
 				<td>0</td>
@@ -26,6 +28,7 @@ digraph Java {
 	n3[label=<
 		<table border='0' cellborder='1' cellspacing='0'>
 			<tr>
+				<td>int[]</td>
 				<td>0</td>
 				<td>0</td>
 				<td>0</td>
@@ -38,6 +41,7 @@ digraph Java {
 	n4[label=<
 		<table border='0' cellborder='1' cellspacing='0'>
 			<tr>
+				<td>int[]</td>
 				<td>0</td>
 				<td>0</td>
 				<td>0</td>
@@ -50,6 +54,7 @@ digraph Java {
 	n5[label=<
 		<table border='0' cellborder='1' cellspacing='0'>
 			<tr>
+				<td>int[]</td>
 				<td>0</td>
 				<td>0</td>
 				<td>0</td>

--- a/jol-core/src/test/java/org/openjdk/jol/ljv/approvals/LJVTest.stringIntern.approved.txt
+++ b/jol-core/src/test/java/org/openjdk/jol/ljv/approvals/LJVTest.stringIntern.approved.txt
@@ -4,6 +4,7 @@ digraph Java {
 	n1[label=<
 		<table border='0' cellborder='1' cellspacing='0' cellpadding='9'>
 			<tr>
+				<td>Object[]</td>
 				<td port="f0"></td>
 				<td port="f1"></td>
 			</tr>
@@ -12,24 +13,22 @@ digraph Java {
 	n2[label=<
 		<table border='0' cellborder='1' cellspacing='0'>
 			<tr>
-				<td rowspan='3'>String</td>
+				<td rowspan='2'>String</td>
 			</tr>
 			<tr>
 				<td>hash: 0</td>
-			</tr>
-			<tr>
-				<td>coder: 0</td>
 			</tr>
 		</table>
 	>];
 	n3[label=<
 		<table border='0' cellborder='1' cellspacing='0'>
 			<tr>
-				<td>72</td>
-				<td>101</td>
-				<td>108</td>
-				<td>108</td>
-				<td>111</td>
+				<td>char[]</td>
+				<td>H</td>
+				<td>e</td>
+				<td>l</td>
+				<td>l</td>
+				<td>o</td>
 			</tr>
 		</table>
 	>];

--- a/jol-core/src/test/java/org/openjdk/jol/ljv/approvals/LJVTest.stringIsNotAPrimitiveType.approved.txt
+++ b/jol-core/src/test/java/org/openjdk/jol/ljv/approvals/LJVTest.stringIsNotAPrimitiveType.approved.txt
@@ -4,24 +4,22 @@ digraph Java {
 	n1[label=<
 		<table border='0' cellborder='1' cellspacing='0'>
 			<tr>
-				<td rowspan='3'>String</td>
+				<td rowspan='2'>String</td>
 			</tr>
 			<tr>
 				<td>hash: 0</td>
-			</tr>
-			<tr>
-				<td>coder: 0</td>
 			</tr>
 		</table>
 	>];
 	n2[label=<
 		<table border='0' cellborder='1' cellspacing='0'>
 			<tr>
-				<td>72</td>
-				<td>101</td>
-				<td>108</td>
-				<td>108</td>
-				<td>111</td>
+				<td>char[]</td>
+				<td>H</td>
+				<td>e</td>
+				<td>l</td>
+				<td>l</td>
+				<td>o</td>
 			</tr>
 		</table>
 	>];

--- a/jol-core/src/test/java/org/openjdk/jol/ljv/approvals/LJVTest.testArrayWithHighlighting.approved.txt
+++ b/jol-core/src/test/java/org/openjdk/jol/ljv/approvals/LJVTest.testArrayWithHighlighting.approved.txt
@@ -17,9 +17,13 @@ digraph Java {
 	n2[label=<
 		<table border='0' cellborder='1' cellspacing='0'>
 			<tr>
+				<td>Object[]</td>
 				<td bgcolor="yellow">null</td>
 				<td bgcolor="yellow">null</td>
 				<td>3</td>
+				<td>null</td>
+				<td>null</td>
+				<td>null</td>
 				<td>null</td>
 				<td>null</td>
 			</tr>

--- a/jol-core/src/test/java/org/openjdk/jol/ljv/approvals/LJVTest.testEmptyArray.approved.txt
+++ b/jol-core/src/test/java/org/openjdk/jol/ljv/approvals/LJVTest.testEmptyArray.approved.txt
@@ -1,0 +1,11 @@
+digraph Java {
+	rankdir="TB";
+	node[shape=plaintext]
+	n1[label=<
+		<table border='0' cellborder='1' cellspacing='0'>
+			<tr>
+				<td>int[][]</td>
+			</tr>
+		</table>
+	>];
+}

--- a/jol-core/src/test/java/org/openjdk/jol/ljv/approvals/LJVTest.twoObjectsLinksToOneArray.approved.txt
+++ b/jol-core/src/test/java/org/openjdk/jol/ljv/approvals/LJVTest.twoObjectsLinksToOneArray.approved.txt
@@ -11,6 +11,7 @@ digraph Java {
 	n2[label=<
 		<table border='0' cellborder='1' cellspacing='0'>
 			<tr>
+				<td>int[]</td>
 				<td>1</td>
 				<td>2</td>
 				<td>3</td>

--- a/jol-core/src/test/java/org/openjdk/jol/ljv/approvals/LJVTest.wrappedObjects.approved.txt
+++ b/jol-core/src/test/java/org/openjdk/jol/ljv/approvals/LJVTest.wrappedObjects.approved.txt
@@ -45,29 +45,27 @@ digraph Java {
 	n5[label=<
 		<table border='0' cellborder='1' cellspacing='0'>
 			<tr>
-				<td rowspan='3'>String</td>
+				<td rowspan='2'>String</td>
 			</tr>
 			<tr>
 				<td>hash: 0</td>
-			</tr>
-			<tr>
-				<td>coder: 0</td>
 			</tr>
 		</table>
 	>];
 	n6[label=<
 		<table border='0' cellborder='1' cellspacing='0'>
 			<tr>
-				<td>72</td>
-				<td>101</td>
-				<td>108</td>
-				<td>108</td>
-				<td>111</td>
-				<td>87</td>
-				<td>111</td>
-				<td>114</td>
-				<td>108</td>
-				<td>100</td>
+				<td>char[]</td>
+				<td>H</td>
+				<td>e</td>
+				<td>l</td>
+				<td>l</td>
+				<td>o</td>
+				<td>W</td>
+				<td>o</td>
+				<td>r</td>
+				<td>l</td>
+				<td>d</td>
 			</tr>
 		</table>
 	>];
@@ -76,25 +74,23 @@ digraph Java {
 	n7[label=<
 		<table border='0' cellborder='1' cellspacing='0'>
 			<tr>
-				<td rowspan='3'>String</td>
+				<td rowspan='2'>String</td>
 			</tr>
 			<tr>
 				<td>hash: 0</td>
-			</tr>
-			<tr>
-				<td>coder: 0</td>
 			</tr>
 		</table>
 	>];
 	n8[label=<
 		<table border='0' cellborder='1' cellspacing='0'>
 			<tr>
-				<td>72</td>
-				<td>69</td>
-				<td>76</td>
-				<td>76</td>
-				<td>32</td>
-				<td>79</td>
+				<td>char[]</td>
+				<td>H</td>
+				<td>E</td>
+				<td>L</td>
+				<td>L</td>
+				<td> </td>
+				<td>O</td>
 			</tr>
 		</table>
 	>];

--- a/jol-core/src/test/java/org/openjdk/jol/ljv/provider/impl/ChangingArrayElementHighlighterTest.java
+++ b/jol-core/src/test/java/org/openjdk/jol/ljv/provider/impl/ChangingArrayElementHighlighterTest.java
@@ -37,7 +37,7 @@ public class ChangingArrayElementHighlighterTest extends VersionGuardedTest {
 
     @Test
     public void checksChangedElements() {
-        assumeTrue(is11());
+        assumeTrue(is8());
         int[] arr = new int[]{1, 2, 3};
         for (int i = 0; i < arr.length; i++) {
 

--- a/jol-core/src/test/java/org/openjdk/jol/ljv/provider/impl/NewObjectHighlighterTest.java
+++ b/jol-core/src/test/java/org/openjdk/jol/ljv/provider/impl/NewObjectHighlighterTest.java
@@ -34,7 +34,7 @@ import static org.openjdk.jol.ljv.provider.impl.NewObjectHighlighter.HIGHLIGHT;
 public class NewObjectHighlighterTest extends VersionGuardedTest {
     @Test
     public void newObjectsAreHighlighted() {
-        assumeTrue(is11());
+        assumeTrue(is8());
         Object o1 = new Object();
         Object o2 = new Object();
         NewObjectHighlighter highlighter = new NewObjectHighlighter();


### PR DESCRIPTION
Currently, visualization of an empty array produces invalid DOT (see https://github.com/atp-mipt/ljv/issues/28)

The solution proposed is as discussed in that issue in 2021 (we now show array component type as well, also treating primitive types and "multidimensional" arrays correctly, that is `int[]`, `int[][]` etc).

This PR also changes the expected version of Java for LJV approval tests from 11 to 8 in order to simplify development of LJV as a part of JOL.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903652](https://bugs.openjdk.org/browse/CODETOOLS-7903652): JOL: Fix empty arrays visualization in LJV (**Bug** - P4)


### Reviewers
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jol.git pull/57/head:pull/57` \
`$ git checkout pull/57`

Update a local copy of the PR: \
`$ git checkout pull/57` \
`$ git pull https://git.openjdk.org/jol.git pull/57/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 57`

View PR using the GUI difftool: \
`$ git pr show -t 57`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jol/pull/57.diff">https://git.openjdk.org/jol/pull/57.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jol/pull/57#issuecomment-1929049786)