### PR TITLE
7903778: JOL: Add utility for creating objects via factory method when unable to create via constructor

### DIFF
--- a/jol-cli/pom.xml
+++ b/jol-cli/pom.xml
@@ -143,6 +143,11 @@ questions.
             <artifactId>jopt-simple</artifactId>
             <version>4.6</version>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <properties>

--- a/jol-cli/src/main/java/org/openjdk/jol/operations/ObjectExternals.java
+++ b/jol-cli/src/main/java/org/openjdk/jol/operations/ObjectExternals.java
@@ -45,9 +45,9 @@ public class ObjectExternals extends ClasspathedOperation {
         return "Show object externals: objects reachable from a given instance";
     }
 
-    public void runWith(Class<?> klass) throws Exception {
+    public void runWith(Class<?> factoryClass, Class<?> klass) throws Exception {
         try {
-            Object o = tryInstantiate(klass);
+            Object o = tryInstantiate(factoryClass, klass);
             out.println(GraphLayout.parseInstance(o).toPrintable());
         } catch (NoSuchMethodException | InstantiationException e) {
             throw new IllegalStateException("Instantiation exception, does the class have the default constructor?", e);

--- a/jol-cli/src/main/java/org/openjdk/jol/operations/ObjectFootprint.java
+++ b/jol-cli/src/main/java/org/openjdk/jol/operations/ObjectFootprint.java
@@ -45,9 +45,9 @@ public class ObjectFootprint extends ClasspathedOperation {
         return "Show the footprint of all objects reachable from a sample instance";
     }
 
-    public void runWith(Class<?> klass) throws Exception {
+    public void runWith(Class<?> factoryClass, Class<?> klass) throws Exception {
         try {
-            Object o = tryInstantiate(klass);
+            Object o = tryInstantiate(factoryClass, klass);
             out.println(GraphLayout.parseInstance(o).toFootprint());
         } catch (NoSuchMethodException | InstantiationException e) {
             throw new IllegalStateException("Instantiation exception, does the class have the default constructor?", e);

--- a/jol-cli/src/main/java/org/openjdk/jol/operations/ObjectInternals.java
+++ b/jol-cli/src/main/java/org/openjdk/jol/operations/ObjectInternals.java
@@ -45,9 +45,9 @@ public class ObjectInternals extends ClasspathedOperation {
         return "Show object internals: field layout, default contents, object header";
     }
 
-    public void runWith(Class<?> klass) throws Exception {
+    public void runWith(Class<?> factoryClass, Class<?> klass) throws Exception {
         try {
-            Object o = tryInstantiate(klass);
+            Object o = tryInstantiate(factoryClass, klass);
             out.println(ClassLayout.parseInstance(o).toPrintable());
         } catch (NoSuchMethodException | InstantiationException | IllegalAccessException e) {
             out.println("Failed to find matching constructor, falling back to class-only introspection.");

--- a/jol-cli/src/main/java/org/openjdk/jol/operations/ObjectInternalsEstimates.java
+++ b/jol-cli/src/main/java/org/openjdk/jol/operations/ObjectInternalsEstimates.java
@@ -51,7 +51,7 @@ public class ObjectInternalsEstimates extends ClasspathedOperation {
     }
 
     @Override
-    protected void runWith(Class<?> klass) {
+    protected void runWith(Class<?> factoryClass, Class<?> klass) {
         List<Layouter> layouters = new ArrayList<>();
 
         for (DataModel model : EstimatedModels.MODELS_JDK8) {

--- a/jol-cli/src/test/java/org/openjdk/jol/operations/ClasspathedOperationTest.java
+++ b/jol-cli/src/test/java/org/openjdk/jol/operations/ClasspathedOperationTest.java
@@ -1,0 +1,82 @@
+package org.openjdk.jol.operations;
+
+import org.junit.Test;
+
+import java.util.Objects;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/** Tests for {@link ClasspathedOperation}. */
+public final class ClasspathedOperationTest {
+
+    @Test
+    public void testTryInstantiate() throws Exception {
+
+        final ClasspathedOperation classpathedOperation = new ClasspathedOperation() {
+            @Override
+            public String label() {
+                return "test";
+            }
+
+            @Override
+            public String description() {
+                return "test";
+            }
+
+            @Override
+            protected void runWith(final Class<?> factoryClass, final Class<?> klass) throws Exception {
+              throw new UnsupportedOperationException();
+            }
+        };
+
+        // Falls back to constructor if factory fails:
+        assertNotNull(classpathedOperation.tryInstantiate(null, Object.class));
+        assertNotNull(classpathedOperation.tryInstantiate(Object.class, Object.class));
+        assertNotNull(classpathedOperation.tryInstantiate(TestFactory.class, Object.class));
+
+        try {
+            classpathedOperation.tryInstantiate(null, RequiresFactory.class);
+            fail("Instantiated " + RequiresFactory.class.getSimpleName() + " without factory.");
+        } catch (final Exception e) {
+           // Expected.
+        }
+
+        try {
+            classpathedOperation.tryInstantiate(InvalidFactory.class, RequiresFactory.class);
+            fail("Instantiated " + RequiresFactory.class.getSimpleName() + " without valid factory.");
+        } catch (final Exception e) {
+            // Expected.
+        }
+
+        // Factory is used.
+        Object o = classpathedOperation.tryInstantiate(TestFactory.class, RequiresFactory.class);
+        assertNotNull(o);
+        assertTrue(o instanceof RequiresFactory);
+    }
+
+    public static final class RequiresFactory {
+       public RequiresFactory(final Object object) {
+           Objects.requireNonNull(object);
+       }
+    }
+
+    public static final class TestFactory {
+        public static <T> T newInstance(final Class<T> klass) {
+            if (RequiresFactory.class.equals(klass)) {
+                return klass.cast(new RequiresFactory(new Object()));
+            }
+
+            return null;
+        }
+    }
+
+    public static final class InvalidFactory {
+
+        public static <T> T newInstance(final Class<T> klass) {
+            // Always creates objects, but lies and claims they are of type T.
+            return (T) new Object();
+        }
+    }
+}


### PR DESCRIPTION
Adds CLI option to provide a factory FQCN which can create objects that you want to analyze. This is useful in situations where you have dependency classes or JDK classes that require non-null objects or have other validation in the constructor. These kinds of classes can't easily be modified, so it's nice to provide an alternative option for creating them.

For example:

```
    public static final class RequiresFactory {
       public RequiresFactory(final String string) {
           Objects.requireNonNull(string);
           if (string.isEmpty()) {
               throw new IllegalArgumentException("string must not be empty");
           }
       }
    }
```

Usage:

```
java -jar jol-cli.jar internals --classpath my-classes.jar --factory my.Factory my.RequiresFactory
```

Where `my.Factory` is:

```
public class Factory {
    public static <T> T newInstance(Class<T> aClass) {

        if (aClass.equals(RequiresFactory.class)) {
            return aClass.cast(new RequiresFactory("test"));
        }

        throw new UnsupportedOperationException(aClass.getTypeName());
    }
}
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7903778](https://bugs.openjdk.org/browse/CODETOOLS-7903778): JOL: Add utility for creating objects via factory method when unable to create via constructor (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jol.git pull/58/head:pull/58` \
`$ git checkout pull/58`

Update a local copy of the PR: \
`$ git checkout pull/58` \
`$ git pull https://git.openjdk.org/jol.git pull/58/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 58`

View PR using the GUI difftool: \
`$ git pr show -t 58`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jol/pull/58.diff">https://git.openjdk.org/jol/pull/58.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jol/pull/58#issuecomment-2085676654)