### PR TITLE
CODETOOLS-7903905: JOL: Simplify Lilliput headump-estimates

### DIFF
--- a/jol-cli/src/main/java/org/openjdk/jol/operations/EstimatedModels.java
+++ b/jol-cli/src/main/java/org/openjdk/jol/operations/EstimatedModels.java
@@ -31,23 +31,23 @@ public class EstimatedModels {
 
     static final DataModel[] MODELS_JDK8 = new DataModel[]{
             new Model32(),
-            new Model64(false, false),
-            new Model64(true, true),
+            new Model64(false, false, 8),
+            new Model64(true, true, 8),
             new Model64(true, true, 16),
     };
 
     static final DataModel[] MODELS_JDK15 = new DataModel[]{
-            new Model64(false, true),
+            new Model64(false, true, 8),
             new Model64(false, true, 16),
     };
 
     static final DataModel[] MODELS_LILLIPUT = new DataModel[]{
-            new Model64_Lilliput(false, 8,  false),
-            new Model64_Lilliput(true,  8,  false),
-            new Model64_Lilliput(true,  16, false),
-            new Model64_Lilliput(false, 8,  true),
-            new Model64_Lilliput(true,  8,  true),
-            new Model64_Lilliput(true,  16, true),
+            new Model64_Lilliput(false, 8,  1),
+            new Model64_Lilliput(true,  8,  1),
+            new Model64_Lilliput(true,  16, 1),
+            new Model64_Lilliput(false, 8,  2),
+            new Model64_Lilliput(true,  8,  2),
+            new Model64_Lilliput(true,  16, 2),
     };
 
 }

--- a/jol-cli/src/main/java/org/openjdk/jol/operations/EstimatedModels.java
+++ b/jol-cli/src/main/java/org/openjdk/jol/operations/EstimatedModels.java
@@ -42,12 +42,12 @@ public class EstimatedModels {
     };
 
     static final DataModel[] MODELS_LILLIPUT = new DataModel[]{
-            new Model64_Lilliput(false, 8, 8, false),
-            new Model64_Lilliput(true, 8, 8, false),
-            new Model64_Lilliput(true, 16, 8, false),
-            new Model64_Lilliput(false, 8, 8, true),
-            new Model64_Lilliput(true, 8, 8, true),
-            new Model64_Lilliput(true, 16, 8, true),
+            new Model64_Lilliput(false, 8,  false),
+            new Model64_Lilliput(true,  8,  false),
+            new Model64_Lilliput(true,  16, false),
+            new Model64_Lilliput(false, 8,  true),
+            new Model64_Lilliput(true,  8,  true),
+            new Model64_Lilliput(true,  16, true),
     };
 
 }

--- a/jol-cli/src/main/java/org/openjdk/jol/operations/HeapDumpEstimates.java
+++ b/jol-cli/src/main/java/org/openjdk/jol/operations/HeapDumpEstimates.java
@@ -113,7 +113,7 @@ public class HeapDumpEstimates implements Operation {
         out.println("=== Stock 64-bit OpenJDK (JDK < 15)");
         out.println();
 
-        long jdk8_noCoops =         computeWithLayouter(data, new HotSpotLayouter(new Model64(false, false), 8));
+        long jdk8_noCoops =         computeWithLayouter(data, new HotSpotLayouter(new Model64(false, false, 8), 8));
         long jdk8_coops =           computeWithLayouter(data, new HotSpotLayouter(new Model64(true, true,   8), 8));
         long jdk8_coops_align16 =   computeWithLayouter(data, new HotSpotLayouter(new Model64(true, true,  16), 8));
         long jdk8_coops_align32 =   computeWithLayouter(data, new HotSpotLayouter(new Model64(true, true,  32), 8));
@@ -136,7 +136,7 @@ public class HeapDumpEstimates implements Operation {
         }
         out.println();
 
-        long jdk15_noCoops =        computeWithLayouter(data, new HotSpotLayouter(new Model64(false, true), 15));
+        long jdk15_noCoops =        computeWithLayouter(data, new HotSpotLayouter(new Model64(false, true,  8), 15));
         long jdk15_coops =          computeWithLayouter(data, new HotSpotLayouter(new Model64(true, true,   8), 15));
         long jdk15_coops_align16 =  computeWithLayouter(data, new HotSpotLayouter(new Model64(true, true,  16), 15));
         long jdk15_coops_align32 =  computeWithLayouter(data, new HotSpotLayouter(new Model64(true, true,  32), 15));
@@ -144,7 +144,7 @@ public class HeapDumpEstimates implements Operation {
         long jdk15_coops_align128 = computeWithLayouter(data, new HotSpotLayouter(new Model64(true, true, 128), 15));
         long jdk15_coops_align256 = computeWithLayouter(data, new HotSpotLayouter(new Model64(true, true, 256), 15));
 
-        out.println("=== Stock 64-bit OpenJDK (JDK >= 15)");
+        out.println("=== Stock 64-bit OpenJDK (JDK >= 15): Field Layout Improvements");
         out.println();
 
         {
@@ -163,16 +163,16 @@ public class HeapDumpEstimates implements Operation {
         }
         out.println();
 
-        out.println("=== Experimental 64-bit OpenJDK: Lilliput, 64-bit headers");
+        out.println("=== Experimental 64-bit OpenJDK (JDK >= 24): Lilliput 1 (64-bit headers)");
         out.println();
 
-        long jdkLilliput_noCoops =          computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(false,  8,   false), 99));
-        long jdkLilliput_coops =            computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true,   8,   false), 99));
-        long jdkLilliput_coops_align16 =    computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true,  16,   false), 99));
-        long jdkLilliput_coops_align32 =    computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true,  32,   false), 99));
-        long jdkLilliput_coops_align64 =    computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true,  64,   false), 99));
-        long jdkLilliput_coops_align128 =   computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true, 128,   false), 99));
-        long jdkLilliput_coops_align256 =   computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true, 256,   false), 99));
+        long jdkLilliput_noCoops =          computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(false,  8,   1), 99));
+        long jdkLilliput_coops =            computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true,   8,   1), 99));
+        long jdkLilliput_coops_align16 =    computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true,  16,   1), 99));
+        long jdkLilliput_coops_align32 =    computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true,  32,   1), 99));
+        long jdkLilliput_coops_align64 =    computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true,  64,   1), 99));
+        long jdkLilliput_coops_align128 =   computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true, 128,   1), 99));
+        long jdkLilliput_coops_align256 =   computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true, 256,   1), 99));
 
         {
             out.printf("%37s %s%n", "", "Upgrade From:");
@@ -190,21 +190,21 @@ public class HeapDumpEstimates implements Operation {
         }
         out.println();
 
-        out.println("=== Experimental 64-bit OpenJDK: Lilliput, 32-bit headers");
+        out.println("=== Experimental 64-bit OpenJDK (Prototype): Lilliput 2 (32-bit headers)");
         out.println();
 
-        long jdkLilliput32_noCoops =        computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(false,  8,   true), 99));
-        long jdkLilliput32_coops =          computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true,   8,   true), 99));
-        long jdkLilliput32_coops_align16 =  computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true,  16,   true), 99));
-        long jdkLilliput32_coops_align32 =  computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true,  32,   true), 99));
-        long jdkLilliput32_coops_align64 =  computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true,  64,   true), 99));
-        long jdkLilliput32_coops_align128 = computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true, 128,   true), 99));
-        long jdkLilliput32_coops_align256 = computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true, 256,   true), 99));
+        long jdkLilliput32_noCoops =        computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(false,  8,   2), 99));
+        long jdkLilliput32_coops =          computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true,   8,   2), 99));
+        long jdkLilliput32_coops_align16 =  computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true,  16,   2), 99));
+        long jdkLilliput32_coops_align32 =  computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true,  32,   2), 99));
+        long jdkLilliput32_coops_align64 =  computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true,  64,   2), 99));
+        long jdkLilliput32_coops_align128 = computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true, 128,   2), 99));
+        long jdkLilliput32_coops_align256 = computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true, 256,   2), 99));
 
         {
             out.printf("%37s %s%n", "", "Upgrade From:");
             out.printf("%10s, %10s, %10s, %10s, %10s, %10s,     %s%n",
-                    "Footprint", "Overhead", "JVM Mode", "JDK < 15", "JDK >= 15", "Lill-64", "Description"
+                    "Footprint", "Overhead", "JVM Mode", "JDK < 15", "JDK >= 15", "Lilliput 1", "Description"
             );
 
             printLine(msg_noCoops_ccp,    rawSize,  jdkLilliput32_noCoops,        jdkLilliput32_coops, jdk8_noCoops,          jdk15_noCoops,          jdkLilliput_noCoops);
@@ -212,7 +212,7 @@ public class HeapDumpEstimates implements Operation {
             printLine(msg_coops_align16,  rawSize,  jdkLilliput32_coops_align16,  jdkLilliput32_coops, jdk8_coops_align16,    jdk15_coops_align16,    jdkLilliput_coops_align16);
             printLine(msg_coops_align32,  rawSize,  jdkLilliput32_coops_align32,  jdkLilliput32_coops, jdk8_coops_align32,    jdk15_coops_align32,    jdkLilliput_coops_align32);
             printLine(msg_coops_align64,  rawSize,  jdkLilliput32_coops_align64,  jdkLilliput32_coops, jdk8_coops_align64,    jdk15_coops_align64,    jdkLilliput_coops_align64);
-            printLine(msg_coops_align128, rawSize,  jdkLilliput32_coops_align128, jdkLilliput32_coops, jdk8_coops_align256,   jdk15_coops_align128,   jdkLilliput_coops_align128);
+            printLine(msg_coops_align128, rawSize,  jdkLilliput32_coops_align128, jdkLilliput32_coops, jdk8_coops_align128,   jdk15_coops_align128,   jdkLilliput_coops_align128);
             printLine(msg_coops_align256, rawSize,  jdkLilliput32_coops_align256, jdkLilliput32_coops, jdk8_coops_align256,   jdk15_coops_align256,   jdkLilliput_coops_align256);
         }
         out.println();

--- a/jol-cli/src/main/java/org/openjdk/jol/operations/HeapDumpEstimates.java
+++ b/jol-cli/src/main/java/org/openjdk/jol/operations/HeapDumpEstimates.java
@@ -166,13 +166,13 @@ public class HeapDumpEstimates implements Operation {
         out.println("=== Experimental 64-bit OpenJDK: Lilliput, 64-bit headers");
         out.println();
 
-        long jdkLilliput_noBase_noCoops =          computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(false,  8,    8, false), 99));
-        long jdkLilliput_noBase_coops =            computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true,   8,    8, false), 99));
-        long jdkLilliput_noBase_coops_align16 =    computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true,  16,    8, false), 99));
-        long jdkLilliput_noBase_coops_align32 =    computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true,  32,    8, false), 99));
-        long jdkLilliput_noBase_coops_align64 =    computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true,  64,    8, false), 99));
-        long jdkLilliput_noBase_coops_align128 =   computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true, 128,    8, false), 99));
-        long jdkLilliput_noBase_coops_align256 =   computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true, 256,    8, false), 99));
+        long jdkLilliput_noCoops =          computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(false,  8,   false), 99));
+        long jdkLilliput_coops =            computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true,   8,   false), 99));
+        long jdkLilliput_coops_align16 =    computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true,  16,   false), 99));
+        long jdkLilliput_coops_align32 =    computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true,  32,   false), 99));
+        long jdkLilliput_coops_align64 =    computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true,  64,   false), 99));
+        long jdkLilliput_coops_align128 =   computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true, 128,   false), 99));
+        long jdkLilliput_coops_align256 =   computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true, 256,   false), 99));
 
         {
             out.printf("%37s %s%n", "", "Upgrade From:");
@@ -180,27 +180,26 @@ public class HeapDumpEstimates implements Operation {
                     "Footprint", "Overhead", "JVM Mode", "JDK < 15", "JDK >= 15", "Description"
             );
 
-            printLine(msg_noCoops_ccp,      rawSize, jdkLilliput_noBase_noCoops,            jdkLilliput_noBase_coops, jdk8_noCoops,         jdk15_noCoops);
-            printLine(msg_coops,            rawSize, jdkLilliput_noBase_coops,              jdkLilliput_noBase_coops, jdk8_coops,           jdk15_coops);
-            printLine(msg_coops_align16,    rawSize, jdkLilliput_noBase_coops_align16,      jdkLilliput_noBase_coops, jdk8_coops_align16,   jdk15_coops_align16);
-            printLine(msg_coops_align32,    rawSize, jdkLilliput_noBase_coops_align32,      jdkLilliput_noBase_coops, jdk8_coops_align32,   jdk15_coops_align32);
-            printLine(msg_coops_align64,    rawSize, jdkLilliput_noBase_coops_align64,      jdkLilliput_noBase_coops, jdk8_coops_align64,   jdk15_coops_align64);
-            printLine(msg_coops_align128,   rawSize, jdkLilliput_noBase_coops_align128,     jdkLilliput_noBase_coops, jdk8_coops_align128,  jdk15_coops_align128);
-            printLine(msg_coops_align256,   rawSize, jdkLilliput_noBase_coops_align256,     jdkLilliput_noBase_coops, jdk8_coops_align256,  jdk15_coops_align256);
-
+            printLine(msg_noCoops_ccp,      rawSize, jdkLilliput_noCoops,          jdkLilliput_coops, jdk8_noCoops,           jdk15_noCoops);
+            printLine(msg_coops,            rawSize, jdkLilliput_coops,            jdkLilliput_coops, jdk8_coops,             jdk15_coops);
+            printLine(msg_coops_align16,    rawSize, jdkLilliput_coops_align16,    jdkLilliput_coops, jdk8_coops_align16,     jdk15_coops_align16);
+            printLine(msg_coops_align32,    rawSize, jdkLilliput_coops_align32,    jdkLilliput_coops, jdk8_coops_align32,     jdk15_coops_align32);
+            printLine(msg_coops_align64,    rawSize, jdkLilliput_coops_align64,    jdkLilliput_coops, jdk8_coops_align64,     jdk15_coops_align64);
+            printLine(msg_coops_align128,   rawSize, jdkLilliput_coops_align128,   jdkLilliput_coops, jdk8_coops_align128,    jdk15_coops_align128);
+            printLine(msg_coops_align256,   rawSize, jdkLilliput_coops_align256,   jdkLilliput_coops, jdk8_coops_align256,    jdk15_coops_align256);
         }
         out.println();
 
-        out.println("=== Experimental 64-bit OpenJDK: Lilliput, 64-bit headers, array base improvements");
+        out.println("=== Experimental 64-bit OpenJDK: Lilliput, 32-bit headers");
         out.println();
 
-        long jdkLilliput_base_noCoops =          computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(false,  8,  4, false), 99));
-        long jdkLilliput_base_coops =            computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true,   8,  4, false), 99));
-        long jdkLilliput_base_coops_align16 =    computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true,  16,  4, false), 99));
-        long jdkLilliput_base_coops_align32 =    computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true,  32,  4, false), 99));
-        long jdkLilliput_base_coops_align64 =    computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true,  64,  4, false), 99));
-        long jdkLilliput_base_coops_align128 =   computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true, 128,  4, false), 99));
-        long jdkLilliput_base_coops_align256 =   computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true, 256,  4, false), 99));
+        long jdkLilliput32_noCoops =        computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(false,  8,   true), 99));
+        long jdkLilliput32_coops =          computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true,   8,   true), 99));
+        long jdkLilliput32_coops_align16 =  computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true,  16,   true), 99));
+        long jdkLilliput32_coops_align32 =  computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true,  32,   true), 99));
+        long jdkLilliput32_coops_align64 =  computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true,  64,   true), 99));
+        long jdkLilliput32_coops_align128 = computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true, 128,   true), 99));
+        long jdkLilliput32_coops_align256 = computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true, 256,   true), 99));
 
         {
             out.printf("%37s %s%n", "", "Upgrade From:");
@@ -208,40 +207,13 @@ public class HeapDumpEstimates implements Operation {
                     "Footprint", "Overhead", "JVM Mode", "JDK < 15", "JDK >= 15", "Lill-64", "Description"
             );
 
-            printLine(msg_noCoops_ccp,      rawSize, jdkLilliput_base_noCoops,          jdkLilliput_base_coops, jdk8_noCoops,           jdk15_noCoops,          jdkLilliput_noBase_noCoops);
-            printLine(msg_coops,            rawSize, jdkLilliput_base_coops,            jdkLilliput_base_coops, jdk8_coops,             jdk15_coops,            jdkLilliput_noBase_coops);
-            printLine(msg_coops_align16,    rawSize, jdkLilliput_base_coops_align16,    jdkLilliput_base_coops, jdk8_coops_align16,     jdk15_coops_align16,    jdkLilliput_noBase_coops_align16);
-            printLine(msg_coops_align32,    rawSize, jdkLilliput_base_coops_align32,    jdkLilliput_base_coops, jdk8_coops_align32,     jdk15_coops_align32,    jdkLilliput_noBase_coops_align32);
-            printLine(msg_coops_align64,    rawSize, jdkLilliput_base_coops_align64,    jdkLilliput_base_coops, jdk8_coops_align64,     jdk15_coops_align64,    jdkLilliput_noBase_coops_align64);
-            printLine(msg_coops_align128,   rawSize, jdkLilliput_base_coops_align128,   jdkLilliput_base_coops, jdk8_coops_align128,    jdk15_coops_align128,   jdkLilliput_noBase_coops_align128);
-            printLine(msg_coops_align256,   rawSize, jdkLilliput_base_coops_align256,   jdkLilliput_base_coops, jdk8_coops_align256,    jdk15_coops_align256,   jdkLilliput_noBase_coops_align256);
-        }
-        out.println();
-
-        out.println("=== Experimental 64-bit OpenJDK: Lilliput, 32-bit headers");
-        out.println();
-
-        long jdkLilliput32_noCoops =        computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(false,  8, 8, true), 99));
-        long jdkLilliput32_coops =          computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true,   8, 8, true), 99));
-        long jdkLilliput32_coops_align16 =  computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true,  16, 8, true), 99));
-        long jdkLilliput32_coops_align32 =  computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true,  32, 8, true), 99));
-        long jdkLilliput32_coops_align64 =  computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true,  64, 8, true), 99));
-        long jdkLilliput32_coops_align128 = computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true, 128, 8, true), 99));
-        long jdkLilliput32_coops_align256 = computeWithLayouter(data, new HotSpotLayouter(new Model64_Lilliput(true, 256, 8, true), 99));
-
-        {
-            out.printf("%37s %s%n", "", "Upgrade From:");
-            out.printf("%10s, %10s, %10s, %10s, %10s, %10s, %10s,     %s%n",
-                    "Footprint", "Overhead", "JVM Mode", "JDK < 15", "JDK >= 15", "Lill-64", "Lill-64-AB", "Description"
-            );
-
-            printLine(msg_noCoops_ccp,    rawSize,  jdkLilliput32_noCoops,        jdkLilliput32_coops, jdk8_noCoops,          jdk15_noCoops,          jdkLilliput_noBase_noCoops,         jdkLilliput_base_noCoops);
-            printLine(msg_coops,          rawSize,  jdkLilliput32_coops,          jdkLilliput32_coops, jdk8_coops,            jdk15_coops,            jdkLilliput_noBase_coops,           jdkLilliput_base_coops);
-            printLine(msg_coops_align16,  rawSize,  jdkLilliput32_coops_align16,  jdkLilliput32_coops, jdk8_coops_align16,    jdk15_coops_align16,    jdkLilliput_noBase_coops_align16,   jdkLilliput_base_coops_align16);
-            printLine(msg_coops_align32,  rawSize,  jdkLilliput32_coops_align32,  jdkLilliput32_coops, jdk8_coops_align32,    jdk15_coops_align32,    jdkLilliput_noBase_coops_align32,   jdkLilliput_base_coops_align32);
-            printLine(msg_coops_align64,  rawSize,  jdkLilliput32_coops_align64,  jdkLilliput32_coops, jdk8_coops_align64,    jdk15_coops_align64,    jdkLilliput_noBase_coops_align64,   jdkLilliput_base_coops_align64);
-            printLine(msg_coops_align128, rawSize,  jdkLilliput32_coops_align128, jdkLilliput32_coops, jdk8_coops_align256,   jdk15_coops_align128,   jdkLilliput_noBase_coops_align128,  jdkLilliput_base_coops_align128);
-            printLine(msg_coops_align256, rawSize,  jdkLilliput32_coops_align256, jdkLilliput32_coops, jdk8_coops_align256,   jdk15_coops_align256,   jdkLilliput_noBase_coops_align256,  jdkLilliput_base_coops_align256);
+            printLine(msg_noCoops_ccp,    rawSize,  jdkLilliput32_noCoops,        jdkLilliput32_coops, jdk8_noCoops,          jdk15_noCoops,          jdkLilliput_noCoops);
+            printLine(msg_coops,          rawSize,  jdkLilliput32_coops,          jdkLilliput32_coops, jdk8_coops,            jdk15_coops,            jdkLilliput_coops);
+            printLine(msg_coops_align16,  rawSize,  jdkLilliput32_coops_align16,  jdkLilliput32_coops, jdk8_coops_align16,    jdk15_coops_align16,    jdkLilliput_coops_align16);
+            printLine(msg_coops_align32,  rawSize,  jdkLilliput32_coops_align32,  jdkLilliput32_coops, jdk8_coops_align32,    jdk15_coops_align32,    jdkLilliput_coops_align32);
+            printLine(msg_coops_align64,  rawSize,  jdkLilliput32_coops_align64,  jdkLilliput32_coops, jdk8_coops_align64,    jdk15_coops_align64,    jdkLilliput_coops_align64);
+            printLine(msg_coops_align128, rawSize,  jdkLilliput32_coops_align128, jdkLilliput32_coops, jdk8_coops_align256,   jdk15_coops_align128,   jdkLilliput_coops_align128);
+            printLine(msg_coops_align256, rawSize,  jdkLilliput32_coops_align256, jdkLilliput32_coops, jdk8_coops_align256,   jdk15_coops_align256,   jdkLilliput_coops_align256);
         }
         out.println();
     }

--- a/jol-cli/src/main/java/org/openjdk/jol/operations/ObjectInternalsEstimates.java
+++ b/jol-cli/src/main/java/org/openjdk/jol/operations/ObjectInternalsEstimates.java
@@ -64,6 +64,7 @@ public class ObjectInternalsEstimates extends ClasspathedOperation {
 
         for (DataModel model : EstimatedModels.MODELS_JDK15) {
             layouters.add(new HotSpotLayouter(model, 15));
+            layouters.add(new HotSpotLayouter(model, 23));
         }
 
         for (DataModel model : EstimatedModels.MODELS_LILLIPUT) {

--- a/jol-core/src/main/java/org/openjdk/jol/datamodel/DataModel.java
+++ b/jol-core/src/main/java/org/openjdk/jol/datamodel/DataModel.java
@@ -80,9 +80,10 @@ public interface DataModel {
     int objectAlignment();
 
     /**
-     * Return the minimal alignment for array bases.
+     * Machine address size.
      *
-     * @return minimal array base alignment
+     * @return machine address size, in bytes
      */
-    int arrayBaseAlignment();
+    int addressSize();
+
 }

--- a/jol-core/src/main/java/org/openjdk/jol/datamodel/Model32.java
+++ b/jol-core/src/main/java/org/openjdk/jol/datamodel/Model32.java
@@ -94,8 +94,7 @@ public class Model32 implements DataModel {
     }
 
     @Override
-    public int arrayBaseAlignment() {
-        // Can be just address size
+    public int addressSize() {
         return 4;
     }
 

--- a/jol-core/src/main/java/org/openjdk/jol/datamodel/Model64.java
+++ b/jol-core/src/main/java/org/openjdk/jol/datamodel/Model64.java
@@ -43,10 +43,6 @@ public class Model64 implements DataModel {
         this.align = align;
     }
 
-    public Model64(boolean compressedRefs, boolean compressedClasses) {
-        this(compressedRefs, compressedClasses, 8);
-    }
-
     @Override
     public int markHeaderSize() {
         return 8;
@@ -98,7 +94,7 @@ public class Model64 implements DataModel {
     }
 
     @Override
-    public int arrayBaseAlignment() {
+    public int addressSize() {
         return 8;
     }
 
@@ -107,23 +103,21 @@ public class Model64 implements DataModel {
         return "64-bit model" +
                 ", " + (compRefs ? "" : "NO ") + "compressed references" +
                 ", " + (compKlass ? "" : "NO ") + "compressed classes" +
-                ", " + align + "-byte aligned";
+                ", " + align + "-byte aligned objects";
     }
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
         Model64 model64 = (Model64) o;
-        return align == model64.align;
+        return align == model64.align &&
+                compRefs == model64.compRefs &&
+                compKlass == model64.compKlass;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(align);
+        return Objects.hash(align, compRefs, compKlass);
     }
 }

--- a/jol-core/src/main/java/org/openjdk/jol/datamodel/Model64_Lilliput.java
+++ b/jol-core/src/main/java/org/openjdk/jol/datamodel/Model64_Lilliput.java
@@ -24,6 +24,8 @@
  */
 package org.openjdk.jol.datamodel;
 
+import java.util.Objects;
+
 /**
  * 64 bits, Lilliput (Experimental)
  *
@@ -33,22 +35,22 @@ public class Model64_Lilliput implements DataModel {
 
     private final int align;
     private final boolean compRefs;
-    private final boolean target;
+    private final int version;
 
-    public Model64_Lilliput(boolean compRefs, int align, boolean target) {
+    public Model64_Lilliput(boolean compRefs, int align, int version) {
         this.compRefs = compRefs;
         this.align = align;
-        this.target = target;
+        this.version = version;
     }
 
     @Override
     public int markHeaderSize() {
-        return target ? 1 : 8;
+        return (version >= 2) ? 1 : 8;
     }
 
     @Override
     public int classHeaderSize() {
-        return target ? 3 : 0;
+        return (version >= 2) ? 3 : 0;
     }
 
     @Override
@@ -92,14 +94,14 @@ public class Model64_Lilliput implements DataModel {
     }
 
     @Override
-    public int arrayBaseAlignment() {
-        return 4;
+    public int addressSize() {
+        return 8;
     }
 
     @Override
     public String toString() {
         return "64-bit model" +
-                ", Lilliput (" + (target ? "ultimate target" : "current experiment") + ")" +
+                ", Lilliput " + (version >= 2 ? "2 (32-bit headers)" : "1 (64-bit headers)") +
                 ", " + (compRefs ? "" : "NO ") + "compressed references" +
                 ", compressed classes" +
                 ", " + align + "-byte aligned";
@@ -110,11 +112,11 @@ public class Model64_Lilliput implements DataModel {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         Model64_Lilliput that = (Model64_Lilliput) o;
-        return align == that.align;
+        return align == that.align && compRefs == that.compRefs && version == that.version;
     }
 
     @Override
     public int hashCode() {
-        return align;
+        return Objects.hash(align, compRefs, version);
     }
 }

--- a/jol-core/src/main/java/org/openjdk/jol/datamodel/Model64_Lilliput.java
+++ b/jol-core/src/main/java/org/openjdk/jol/datamodel/Model64_Lilliput.java
@@ -32,18 +32,12 @@ package org.openjdk.jol.datamodel;
 public class Model64_Lilliput implements DataModel {
 
     private final int align;
-    private final int arrayBaseAlign;
     private final boolean compRefs;
     private final boolean target;
 
-    public Model64_Lilliput() {
-        this(false, 8, 8, false);
-    }
-
-    public Model64_Lilliput(boolean compRefs, int align, int arrayBaseAlign, boolean target) {
+    public Model64_Lilliput(boolean compRefs, int align, boolean target) {
         this.compRefs = compRefs;
         this.align = align;
-        this.arrayBaseAlign = target ? 4 : arrayBaseAlign;
         this.target = target;
     }
 
@@ -99,7 +93,7 @@ public class Model64_Lilliput implements DataModel {
 
     @Override
     public int arrayBaseAlignment() {
-        return arrayBaseAlign;
+        return 4;
     }
 
     @Override

--- a/jol-core/src/main/java/org/openjdk/jol/datamodel/ModelVM.java
+++ b/jol-core/src/main/java/org/openjdk/jol/datamodel/ModelVM.java
@@ -73,34 +73,9 @@ public class ModelVM implements DataModel {
         return VM.current().objectAlignment();
     }
 
-    int arrayBaseAlignment;
-
-    private static int guessArrayBaseAlignment(String type) {
-        int byteOff = VM.current().arrayBaseOffset(type);
-        if ((byteOff % 8) == 0) return 8;
-        if ((byteOff % 4) == 0) return 4;
-        if ((byteOff % 2) == 0) return 2;
-        return 1;
-    }
-
     @Override
-    public int arrayBaseAlignment() {
-        if (arrayBaseAlignment != 0) {
-            return arrayBaseAlignment;
-        }
-        int al = Integer.MAX_VALUE;
-        al = Math.min(al, guessArrayBaseAlignment("boolean"));
-        al = Math.min(al, guessArrayBaseAlignment("byte"));
-        al = Math.min(al, guessArrayBaseAlignment("short"));
-        al = Math.min(al, guessArrayBaseAlignment("char"));
-        al = Math.min(al, guessArrayBaseAlignment("int"));
-        al = Math.min(al, guessArrayBaseAlignment("float"));
-        al = Math.min(al, guessArrayBaseAlignment("long"));
-        al = Math.min(al, guessArrayBaseAlignment("double"));
-        al = Math.min(al, guessArrayBaseAlignment("Object"));
-        arrayBaseAlignment = al;
-
-        return al;
+    public int addressSize() {
+        return VM.current().addressSize();
     }
 
     @Override
@@ -108,8 +83,7 @@ public class ModelVM implements DataModel {
         return "Current VM: " +
                 (headerSize() + "-byte object headers, ") +
                 (sizeOf("java.lang.Object") + "-byte references, ") +
-                (objectAlignment() + "-byte aligned objects, ") +
-                (arrayBaseAlignment() + "-byte aligned array bases");
+                (objectAlignment() + "-byte aligned objects");
     }
 
     @Override

--- a/jol-core/src/main/java/org/openjdk/jol/layouters/HotSpotLayouter.java
+++ b/jol-core/src/main/java/org/openjdk/jol/layouters/HotSpotLayouter.java
@@ -79,9 +79,10 @@ public class HotSpotLayouter implements Layouter {
             int base = model.arrayHeaderSize();
             int scale = model.sizeOf(cd.arrayComponentType());
 
-            // Array bases are aligned by HeapWord size:
-            //  https://bugs.openjdk.java.net/browse/JDK-8139457
-            base = MathUtil.align(base, Math.max(model.arrayBaseAlignment(), scale));
+            // Array bases are aligned by HeapWord size in older JDKs
+            //  https://bugs.openjdk.org/browse/JDK-8139457
+            int minArrayBaseAlignment = (jdkVersion >= 23) ? 4 : model.addressSize();
+            base = MathUtil.align(base, Math.max(minArrayBaseAlignment, scale));
 
             long instanceSize = base + cd.arrayLength() * scale;
             instanceSize = MathUtil.align(instanceSize, model.objectAlignment());

--- a/jol-samples/src/main/java/org/openjdk/jol/samples/JOLSample_10_DataModels.java
+++ b/jol-samples/src/main/java/org/openjdk/jol/samples/JOLSample_10_DataModels.java
@@ -70,13 +70,13 @@ public class JOLSample_10_DataModels {
 
     private static final DataModel[] MODELS_JDK8 = new DataModel[]{
             new Model32(),
-            new Model64(false, false),
-            new Model64(true, true),
+            new Model64(false, false, 8),
+            new Model64(true, true, 8),
             new Model64(true, true, 16),
     };
 
     private static final DataModel[] MODELS_JDK15 = new DataModel[]{
-            new Model64(false, true),
+            new Model64(false, true, 8),
             new Model64(false, true, 16),
     };
 


### PR DESCRIPTION
Lilliput was shipped in JDK 24 as experimental option. Current heapdump-esitmates provides *two* estimates: one with array base improvements, and one without. The version of Lilliput in upstream does implement array base improvements unconditionally ([JDK-8139457](https://bugs.openjdk.org/browse/JDK-8139457)). Therefore, we do not need one of the estimates.