### PR TITLE
Read ObjectAlignmentInBytes regardless of UseCompressedOops value

### DIFF
--- a/jol-core/src/main/java/org/openjdk/jol/vm/VMOptions.java
+++ b/jol-core/src/main/java/org/openjdk/jol/vm/VMOptions.java
@@ -57,14 +57,11 @@ class VMOptions {
     }
 
     public static Integer pollObjectAlignment() {
-        if (Boolean.TRUE.equals(pollCompressedOops())) {
-            try {
-                return Integer.valueOf(getString("ObjectAlignmentInBytes"));
-            } catch (Exception exp) {
-                return null;
-            }
+        try {
+            return Integer.valueOf(getString("ObjectAlignmentInBytes"));
+        } catch (Exception exp) {
+            return null;
         }
-        return null;
     }
 
 }


### PR DESCRIPTION
This fixes alignment detection on Generational ZGC

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jol.git pull/63/head:pull/63` \
`$ git checkout pull/63`

Update a local copy of the PR: \
`$ git checkout pull/63` \
`$ git pull https://git.openjdk.org/jol.git pull/63/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 63`

View PR using the GUI difftool: \
`$ git pr show -t 63`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jol/pull/63.diff">https://git.openjdk.org/jol/pull/63.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jol/pull/63#issuecomment-2598597243)
</details>
