### PR TITLE
Uncolorize addresses when using Generational ZGC 

### DIFF
--- a/jol-core/src/main/java/org/openjdk/jol/vm/HotspotUnsafe.java
+++ b/jol-core/src/main/java/org/openjdk/jol/vm/HotspotUnsafe.java
@@ -80,6 +80,7 @@ class HotspotUnsafe implements VirtualMachine {
     private final Sizes sizes;
 
     private final boolean lilliputVM;
+    private final boolean generationalZGCEnabled;
 
     private volatile boolean mfoInitialized;
     private Object mfoUnsafe;
@@ -91,6 +92,8 @@ class HotspotUnsafe implements VirtualMachine {
         U = u;
         instrumentation = inst;
         isAccurate = true;
+
+        generationalZGCEnabled = VMOptions.isGenerationalZGCEnabled();
 
         arrayObjectBase = U.arrayBaseOffset(Object[].class);
 
@@ -118,6 +121,8 @@ class HotspotUnsafe implements VirtualMachine {
         U = u;
         instrumentation = inst;
         isAccurate = false;
+
+        generationalZGCEnabled = VMOptions.isGenerationalZGCEnabled();
 
         arrayObjectBase = U.arrayBaseOffset(Object[].class);
         addressSize = U.addressSize();
@@ -645,7 +650,7 @@ class HotspotUnsafe implements VirtualMachine {
         if (compressedOopsEnabled) {
             return narrowOopBase + (address << narrowOopShift);
         } else {
-            return address;
+            return generationalZGCEnabled ? ZGCAddress.uncolorize(address) : address;
         }
     }
 
@@ -661,7 +666,7 @@ class HotspotUnsafe implements VirtualMachine {
         if (compressedOopsEnabled) {
             return narrowOopBase + (address << narrowOopShift);
         } else {
-            return address;
+            return generationalZGCEnabled ? ZGCAddress.uncolorize(address) : address;
         }
     }
 
@@ -677,7 +682,7 @@ class HotspotUnsafe implements VirtualMachine {
         if (compressedKlassOopsEnabled) {
             return narrowKlassBase + (address << narrowKlassShift);
         } else {
-            return address;
+            return generationalZGCEnabled ? ZGCAddress.uncolorize(address) : address;
         }
     }
 

--- a/jol-core/src/main/java/org/openjdk/jol/vm/VMOptions.java
+++ b/jol-core/src/main/java/org/openjdk/jol/vm/VMOptions.java
@@ -67,4 +67,9 @@ class VMOptions {
         return null;
     }
 
+    public static boolean isGenerationalZGCEnabled() {
+        return ManagementFactory.getGarbageCollectorMXBeans().stream()
+                .anyMatch(bean -> "ZGC Minor Cycles".equals(bean.getName()));
+    }
+
 }

--- a/jol-core/src/main/java/org/openjdk/jol/vm/ZGCAddress.java
+++ b/jol-core/src/main/java/org/openjdk/jol/vm/ZGCAddress.java
@@ -1,0 +1,28 @@
+package org.openjdk.jol.vm;
+
+/**
+ * Utility class for normalizing ZGC addresses by removing color bits
+ *
+ * @see <a href="https://github.com/openjdk/jdk/blob/master/src/hotspot/share/gc/z/zAddress.hpp">Layout description</a>
+ */
+class ZGCAddress {
+    private static final long REMAPPED_BITS_MASK = 0b1111L << 12;
+    private static final long CLEAR_UNUSED_BITS_MASK = (1L << 46) - 1;
+    private static final long COLOR_BITS_COUNT = 16;
+    private static final boolean isAarch = "aarch64".equals(System.getProperty("os.arch"));
+
+    static long uncolorize(long address) {
+        return isAarch ? uncolorizeAarch(address) : uncolorizeNonAarch(address);
+    }
+
+    private static long uncolorizeNonAarch(long address) {
+        int shift = Long.numberOfTrailingZeros(address & REMAPPED_BITS_MASK) + 1;
+        return (address >> shift) & CLEAR_UNUSED_BITS_MASK;
+    }
+
+    private static long uncolorizeAarch(long address) {
+        return (address >> COLOR_BITS_COUNT) & CLEAR_UNUSED_BITS_MASK;
+    }
+
+    private ZGCAddress() {}
+}

--- a/jol-core/src/test/java/org/openjdk/jol/vm/ZGCAddressTest.java
+++ b/jol-core/src/test/java/org/openjdk/jol/vm/ZGCAddressTest.java
@@ -1,0 +1,35 @@
+package org.openjdk.jol.vm;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class ZGCAddressTest {
+    @Test
+    public void testGenerationalZGCAddressUncolorize() {
+        final long[] coloredAddresses;
+        if ("aarch64".equals(System.getProperty("os.arch"))) {
+            coloredAddresses = new long[] {
+                // remapped bits inverted, no address and color overlap
+                0b00100100_00000000_00000000_00111011_10100110_10111000_11100101_00010000L,
+                0b00100100_00000000_00000000_00111011_10100110_10111000_11010101_00010000L,
+                0b00100100_00000000_00000000_00111011_10100110_10111000_10110101_00010000L,
+                0b00100100_00000000_00000000_00111011_10100110_10111000_01110101_00010000L
+            };
+        } else {
+            coloredAddresses = new long[] {
+                0b00100100_00000000_00000000_00111011_10100110_10111000_10000101_00010000L,
+                0b00010010_00000000_00000000_00011101_11010011_01011100_01000101_00010000L,
+                0b00001001_00000000_00000000_00001110_11101001_10101110_00100101_00010000L,
+                0b00000100_10000000_00000000_00000111_01110100_11010111_00010101_00010000L,
+            };
+        }
+
+        for (long address : coloredAddresses) {
+            assertEquals(
+                    0b100100_00000000_00000000_00111011_10100110_10111000L,
+                    ZGCAddress.uncolorize(address)
+            );
+        }
+    }
+}


### PR DESCRIPTION
Because of color bits in lower positions, object alignment size heuristics does not work with generational ZGC. This PR implements address uncolorizing so alignment size and hence object size is calculated correctly