### PR TITLE
7904137: JOL: Improve heap dump parsing speed

### DIFF
--- a/jol-core/src/main/java/org/openjdk/jol/heap/HeapDumpReader.java
+++ b/jol-core/src/main/java/org/openjdk/jol/heap/HeapDumpReader.java
@@ -152,7 +152,7 @@ public class HeapDumpReader {
                 break;
             }
 
-            read_U4(); // relative time
+            skipContents(4); // relative time
             long len = read_U4();
 
             long lastCount = readBytes;
@@ -249,37 +249,20 @@ public class HeapDumpReader {
         int subTag = read_U1();
         switch (subTag) {
             case 0x01:
-                read_ID();
-                read_ID();
+                skipContents(2 * idSize);
                 return;
             case 0x02:
-                read_ID();
-                read_U4();
-                read_U4();
-                return;
             case 0x03:
-                read_ID();
-                read_U4();
-                read_U4();
+            case 0x08:
+                skipContents(idSize + 2*4);
                 return;
             case 0x04:
-                read_ID();
-                read_U4();
+            case 0x06:
+                skipContents(idSize + 1*4);
                 return;
             case 0x05:
-                read_ID();
-                return;
-            case 0x06:
-                read_ID();
-                read_U4();
-                return;
             case 0x07:
-                read_ID();
-                return;
-            case 0x08:
-                read_ID();
-                read_U4();
-                read_U4();
+                skipContents(idSize);
                 return;
             case 0x20:
                 digestClass();

--- a/jol-core/src/main/java/org/openjdk/jol/heap/HeapDumpReader.java
+++ b/jol-core/src/main/java/org/openjdk/jol/heap/HeapDumpReader.java
@@ -99,6 +99,16 @@ public class HeapDumpReader {
         }
     }
 
+    private int read_byte() throws HeapDumpException {
+        try {
+            int read = is.read();
+            readBytes += (read < 0) ? 0 : 1;
+            return read;
+        } catch (IOException e) {
+            throw new HeapDumpException(errorMessage(e.getMessage()));
+        }
+    }
+
     private int read(byte[] b, int size) throws HeapDumpException {
         try {
             int read = is.read(b, 0, size);
@@ -591,11 +601,11 @@ public class HeapDumpReader {
     }
 
     int read_U1() throws HeapDumpException {
-        int read = read(buf, 1);
-        if (read == 1) {
-            return ((int)wrapBuf.get(0) & 0xFF);
+        int read = read_byte();
+        if (read < 0) {
+            throw new HeapDumpException(errorMessage("Unable to read 1 bytes"));
         }
-        throw new HeapDumpException(errorMessage("Unable to read 1 bytes"));
+        return (int)(read & 0xFF);
     }
 
     private String errorMessage(String message) throws HeapDumpException {

--- a/jol-core/src/main/java/org/openjdk/jol/heap/HeapDumpReader.java
+++ b/jol-core/src/main/java/org/openjdk/jol/heap/HeapDumpReader.java
@@ -32,9 +32,7 @@ import org.openjdk.jol.util.Multiset;
 
 import java.io.*;
 import java.nio.ByteBuffer;
-import java.nio.file.Files;
 import java.util.*;
-import java.util.concurrent.TimeUnit;
 import java.util.zip.GZIPInputStream;
 
 /**
@@ -44,6 +42,7 @@ import java.util.zip.GZIPInputStream;
  */
 public class HeapDumpReader {
 
+    private static final int      BUF_SIZE =       128 * 1024;
     private static final int GZIP_BUF_SIZE =       512 * 1024;
     private static final int READ_BUF_SIZE =  4 * 1024 * 1024;
 
@@ -81,7 +80,7 @@ public class HeapDumpReader {
         this.classFields = new Multimap<>();
         this.arrayCounts = new Multiset<>();
         this.classSupers = new HashMap<>();
-        this.buf = new byte[32*1024];
+        this.buf = new byte[BUF_SIZE];
         this.wrapBuf = ByteBuffer.wrap(buf);
     }
 

--- a/jol-core/src/main/java/org/openjdk/jol/heap/HeapDumpReader.java
+++ b/jol-core/src/main/java/org/openjdk/jol/heap/HeapDumpReader.java
@@ -290,7 +290,7 @@ public class HeapDumpReader {
 
     private void digestPrimArray() throws HeapDumpException {
         long id = read_ID(); // array id
-        read_U4(); // stack trace
+        skipContents(4); // stack trace, ignore
         int elements = (int) read_U4(); // always fits
         int typeClass = read_U1();
 
@@ -309,7 +309,7 @@ public class HeapDumpReader {
 
     private void digestObjArray() throws HeapDumpException {
         long id = read_ID(); // array id
-        read_U4(); // stack trace
+        skipContents(4); // stack trace, ignore
         int elements = (int) read_U4(); // always fits
         long klassId = read_ID(); // array class
 
@@ -331,12 +331,11 @@ public class HeapDumpReader {
 
     private void digestInstance() throws HeapDumpException {
         long id = read_ID(); // object id
-        read_U4(); // stack trace
+        skipContents(4); // stack trace, ignore
         long klassID = read_ID();
+        int instanceBytes = (int) read_U4(); // always fits
 
         classCounts.add(klassID);
-
-        int instanceBytes = (int) read_U4(); // always fits
 
         if (visitor != null) {
             byte[] bytes = readContents(instanceBytes);
@@ -352,7 +351,7 @@ public class HeapDumpReader {
 
         String name = classNames.get(klassID);
 
-        read_U4(); // stack trace
+        skipContents(4); // stack trace, ignore
 
         long superKlassID = read_ID();
         if (superKlassID != 0 && classSupers.put(klassID, superKlassID) != null) {

--- a/jol-core/src/main/java/org/openjdk/jol/heap/HeapDumpReader.java
+++ b/jol-core/src/main/java/org/openjdk/jol/heap/HeapDumpReader.java
@@ -295,8 +295,8 @@ public class HeapDumpReader {
         int typeClass = read_U1();
 
         String typeString = getTypeString(typeClass);
-        ClassData thisCD = new ClassData(typeString + "[]", typeString, elements);
-        arrayCounts.add(thisCD);
+        String typeArrayString = getTypeArrayString(typeClass);
+        arrayCounts.add(new ClassData(typeArrayString, typeString, elements));
 
         long len = (long) elements * getSize(typeClass);
         if (visitor != null) {
@@ -317,8 +317,7 @@ public class HeapDumpReader {
 
         // Assume Object as component type, the name of the actual class
         // is what we want for the printouts.
-        ClassData thisCD = new ClassData(name, "Object", elements);
-        arrayCounts.add(thisCD);
+        arrayCounts.add(new ClassData(name, "Object", elements));
 
         long len = (long) elements * idSize;
         if (visitor != null) {
@@ -464,15 +463,9 @@ public class HeapDumpReader {
     }
 
     private String getTypeString(int type) throws HeapDumpException {
-        if (type == 2) {
-            return "Object"; // TODO: Read the exact type;
-        }
-
-        return getPrimitiveTypeString(type);
-    }
-
-    private String getPrimitiveTypeString(int type) throws HeapDumpException {
         switch (type) {
+            case 2:
+                return "Object"; // TODO: Read the exact type;
             case 4:
                 return "boolean";
             case 8:
@@ -489,6 +482,31 @@ public class HeapDumpReader {
                 return "double";
             case 11:
                 return "long";
+            default:
+                throw new HeapDumpException("Unknown type: " + type);
+        }
+    }
+
+    private String getTypeArrayString(int type) throws HeapDumpException {
+        switch (type) {
+            case 2:
+                return "Object[]"; // TODO: Read the exact type;
+            case 4:
+                return "boolean[]";
+            case 8:
+                return "byte[]";
+            case 9:
+                return "short[]";
+            case 5:
+                return "char[]";
+            case 10:
+                return "int[]";
+            case 6:
+                return "float[]";
+            case 7:
+                return "double[]";
+            case 11:
+                return "long[]";
             default:
                 throw new HeapDumpException("Unknown type: " + type);
         }

--- a/jol-core/src/main/java/org/openjdk/jol/heap/HeapDumpReader.java
+++ b/jol-core/src/main/java/org/openjdk/jol/heap/HeapDumpReader.java
@@ -318,7 +318,7 @@ public class HeapDumpReader {
         // Assume Object as component type, the name of the actual class
         // is what we want for the printouts.
         ClassData thisCD = new ClassData(name, "Object", elements);
-        arrayCounts.add(new ClassData(name, "Object", elements));
+        arrayCounts.add(thisCD);
 
         long len = (long) elements * idSize;
         if (visitor != null) {


### PR DESCRIPTION
JOL is often used to parse large heap dumps, and it would be good to see if there are simple opportunities in speeding up the heap dump reader. This change lifts up `heapdump-estimates` speed from 800 MB/sec to 1600 MB/sec on my machines.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Committer](https://openjdk.org/bylaws#committer))

### Issue
 * [CODETOOLS-7904137](https://bugs.openjdk.org/browse/CODETOOLS-7904137): JOL: Improve heap dump parsing speed (**Enhancement** - P4)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jol.git pull/68/head:pull/68` \
`$ git checkout pull/68`

Update a local copy of the PR: \
`$ git checkout pull/68` \
`$ git pull https://git.openjdk.org/jol.git pull/68/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 68`

View PR using the GUI difftool: \
`$ git pr show -t 68`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jol/pull/68.diff">https://git.openjdk.org/jol/pull/68.diff</a>

</details>
<details><summary>Using Webrev</summary>

[Link to Webrev Comment](https://git.openjdk.org/jol/pull/68#issuecomment-3778731620)
</details>
